### PR TITLE
Change previous and next icons

### DIFF
--- a/mini-media-player.js
+++ b/mini-media-player.js
@@ -9,8 +9,8 @@ class MiniMediaPlayer extends LitElement {
         true: 'mdi:pause',
         false: 'mdi:play'
       },
-      'prev': 'mdi:mdi:skip-backward',
-      'next': 'mdi:mdi:skip-forward',
+      'prev': 'mdi:mdi:skip-previous',
+      'next': 'mdi:mdi:skip-next',
       'power': 'mdi:power',
       'volume_up': 'mdi:volume-high',
       'volume_down': 'mdi:volume-medium',


### PR DESCRIPTION
The mdi:skip-previous and mdi:skip-next are used in the standard media player of HA