### PR TITLE
allow to set an icon color different than the text color

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 
   ```yaml
   resources:
-    - url: /local/mini-media-player-bundle.js?v=1.2.1
+    - url: /local/mini-media-player-bundle.js?v=1.2.2
       type: module
   ```
 
@@ -32,14 +32,14 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 2. Grab `mini-media-player-bundle.js`
 
   ```console
-  $ wget https://github.com/kalkih/mini-media-player/releases/download/v1.2.1/mini-media-player-bundle.js
+  $ wget https://github.com/kalkih/mini-media-player/releases/download/v1.2.2/mini-media-player-bundle.js
   ```
 
 3. Add a reference to `mini-media-player-bundle.js` inside your `ui-lovelace.yaml`.
 
   ```yaml
   resources:
-    - url: /local/mini-media-player-bundle.js?v=1.2.1
+    - url: /local/mini-media-player-bundle.js?v=1.2.2
       type: module
   ```
 
@@ -64,7 +64,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 
   ```yaml
   resources:
-    - url: /local/mini-media-player-bundle.js?v=1.2.1
+    - url: /local/mini-media-player-bundle.js?v=1.2.2
       type: module
   ```
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 
 | name | Default | Description |
 |------|---------|-------------|
-| mini-media-player-base-color | var(--primary-text-color) & var(--paper-item-icon-color) | The color of base text, icons & buttons
+| mini-media-player-base-color | var(--primary-text-color) & var(--paper-item-icon-color) | The color of base text & buttons
 | mini-media-player-accent-color | var(--accent-color) | The accent color of UI elements
+| mini-media-player-icon-color |  --mini-media-player-base-color, var(--paper-item-icon-color, #44739e) | The color for icons
 | mini-media-player-overlay-color | rgba(0,0,0,0.5) | The color of the background overlay
 | mini-media-player-overlay-base-color | white | The color of base text, icons & buttons while artwork cover is present
 | mini-media-player-overlay-accent-color | white | The accent color of UI elements while artwork cover is present

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,12 @@
+## v1.2.2
+### CHANGED
+- Adjusted tts text input color
+- Adjustements to active button color
+
+### FIXED
+- Fixed invisible progress bars (#138)
+- Preserve state-icon color on entity icon unless overridden
+
 ## v1.2.1
 ### ADDED
 - New base-color (`mini-media-player-base-color`) theme variable (#130)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mini-media-player",
-  "version": "v1.2.1",
+  "version": "v1.2.2",
   "description": "A minimalistic yet customizable media player card for Home Assistant Lovelace UI",
   "keywords": [
     "home-assistant",

--- a/src/style.js
+++ b/src/style.js
@@ -13,7 +13,7 @@ const style = css`
     --mmp-media-cover-info-color: var(--mini-media-player-media-cover-info-color, --mmp-text-color);
     --mmp-text-color-inverted: var(--disabled-text-color);
     --mmp-active-color: var(--mmp-accent-color);
-    --mmp-icon-color: var(--mini-media-player-icon-color, var(--paper-item-icon-color, #44739e));
+    --mmp-icon-color: var(--mini-media-player-icon-color, --mini-media-player-base-color, var(--paper-item-icon-color, #44739e));
     --mmp-info-opacity: 1;
     --mdc-theme-primary: var(--mmp-text-color);
     --mdc-theme-on-primary: var(--mmp-text-color);

--- a/src/style.js
+++ b/src/style.js
@@ -13,7 +13,7 @@ const style = css`
     --mmp-media-cover-info-color: var(--mini-media-player-media-cover-info-color, --mmp-text-color);
     --mmp-text-color-inverted: var(--disabled-text-color);
     --mmp-active-color: var(--mmp-accent-color);
-    --mmp-icon-color: var(--mini-media-player-icon-color, --mini-media-player-base-color, var(--paper-item-icon-color, #44739e));
+    --mmp-icon-color: var(--mini-media-player-icon-color, var(--mini-media-player-base-color, var(--paper-item-icon-color, #44739e)));
     --mmp-info-opacity: 1;
     --mdc-theme-primary: var(--mmp-text-color);
     --mdc-theme-on-primary: var(--mmp-text-color);

--- a/src/style.js
+++ b/src/style.js
@@ -13,7 +13,7 @@ const style = css`
     --mmp-media-cover-info-color: var(--mini-media-player-media-cover-info-color, --mmp-text-color);
     --mmp-text-color-inverted: var(--disabled-text-color);
     --mmp-active-color: var(--mmp-accent-color);
-    --mmp-icon-color: var(--mini-media-player-base-color, var(--paper-item-icon-color, #44739e));
+    --mmp-icon-color: var(--mini-media-player-icon-color, var(--paper-item-icon-color, #44739e));
     --mmp-info-opacity: 1;
     --mdc-theme-primary: var(--mmp-text-color);
     --mdc-theme-on-primary: var(--mmp-text-color);

--- a/tracker.json
+++ b/tracker.json
@@ -1,8 +1,8 @@
 {
   "mini-media-player-bundle": {
-    "updated_at": "2019-06-29",
-    "version": "1.2.1",
-    "remote_location": "https://github.com/kalkih/mini-media-player/releases/download/v1.2.1/mini-media-player-bundle.js",
+    "updated_at": "2019-07-08",
+    "version": "1.2.2",
+    "remote_location": "https://github.com/kalkih/mini-media-player/releases/download/v1.2.2/mini-media-player-bundle.js",
     "visit_repo": "https://github.com/kalkih/mini-media-player",
     "changelog": "https://github.com/kalkih/mini-media-player/releases/latest"
   }


### PR DESCRIPTION
`mmp-icon-color` was set to the same variable (`mini-media-player-base-color`) as `mmp-base-color` and `mmp-text-color` whereas not having the same fallback color (`paper-item-icon-color` vs. `primary-text-color` for both other).
this PR create a `mini-media-player-icon-color` that allows to consistently set an icon color different from those of base-color and text-color.