### PR TITLE
Updating group handling to support more platforms

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -290,15 +290,15 @@ export default class MediaPlayerObject {
     const options = { entity_id: entity };
     if (checked) {
       options.master = this.config.entity;
-      if (platform === 'sonos') {
-        return this.callService(e, 'join', options, platform);
+      if (platform === 'bluesound') {
+        return this.callService(e, `${platform}_JOIN`, options);
       }
-      this.callService(e, `${platform}_JOIN`, options);
+      this.callService(e, 'join', options, platform);
     } else {
-      if (platform === 'sonos') {
-        return this.callService(e, 'unjoin', options, platform);
+      if (platform === 'bluesound') {
+        return this.callService(e, `${platform}_UNJOIN`, options);
       }
-      this.callService(e, `${platform}_UNJOIN`, options);
+      this.callService(e, 'unjoin', options, platform);
     }
   }
 


### PR DESCRIPTION
Hi!

With the snapcast component now handling multiroom, I realised that group handling wasn't supported by mini media player.
This changes aim to support snapcast mutiroom and future multiroom compatible components as they will have their own domain.
This is the first time I ever touch js so let me know if something is wrong!

Best regards