### PR TITLE
add style var to override linear color stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 | mini-media-player-accent-color | var(--accent-color) | The accent color of UI elements
 | mini-media-player-icon-color |  --mini-media-player-base-color, var(--paper-item-icon-color, #44739e) | The color for icons
 | mini-media-player-overlay-color | rgba(0,0,0,0.5) | The color of the background overlay
+| mini-media-player-overlay-color-stop | 25% | The gradient stop of the background overlay
 | mini-media-player-overlay-base-color | white | The color of base text, icons & buttons while artwork cover is present
 | mini-media-player-overlay-accent-color | white | The accent color of UI elements while artwork cover is present
 | mini-media-player-media-cover-info-color | white | Color of the media information text while artwork cover is present

--- a/src/style.js
+++ b/src/style.js
@@ -7,6 +7,7 @@ const style = css`
     --mmp-accent-color: var(--mini-media-player-accent-color, var(--accent-color, #f39c12));
     --mmp-base-color: var(--mini-media-player-base-color, var(--primary-text-color, #000));
     --mmp-overlay-color: var(--mini-media-player-overlay-color, rgba(0,0,0,0.5));
+    --mmp-overlay-color-stop: var(--mini-media-player-overlay-color-stop, 25%);
     --mmp-overlay-base-color: var(--mini-media-player-overlay-base-color, #fff);
     --mmp-overlay-accent-color: var(--mini-media-player-overlay-accent-color, --mmp-accent-color);
     --mmp-text-color: var(--mini-media-player-base-color, --primary-text-color);
@@ -130,7 +131,7 @@ const style = css`
     content: '';
   }
   ha-card[artwork*='full-cover'].--has-artwork .mmp-player {
-    background: linear-gradient(to top, var(--mmp-overlay-color) 25%, transparent 100%);
+    background: linear-gradient(to top, var(--mmp-overlay-color) var(--mmp-overlay-color-stop), transparent 100%);
     border-bottom-left-radius: var(--ha-card-border-radius, 0);
     border-bottom-right-radius: var(--ha-card-border-radius, 0);
   }


### PR DESCRIPTION
Add an css variable in order to override the default stop color used by linear-gradient when artwork is defined to full-cover.