### PR TITLE
Scalable UI #156

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 | background | string | optional | v0.8.6 | Background image, specify the image url `"/local/background-img.png"` e.g.
 | speaker_group | object | optional | v1.0.0 | Speaker group management/multiroom, see [Speaker group object](#speaker-group-object) for available options.
 | shortcuts | object | optional | v1.0.0 | Media shortcuts in a list or as buttons, see [Shortcut object](#shortcuts-object) for available options.
+| scale | number | optional | v1.5.0 | UI scale modifier, default is `1`.
 
 #### Idle object
 | Name | Type | Default | Description |
@@ -234,6 +235,7 @@ Can be specified by color name, hexadecimal, rgb, rgba, hsl, hsla, basically any
 | mini-media-player-media-cover-info-color | white | Color of the media information text while artwork cover is present
 | mini-media-player-artwork-opacity | 1 | Opacity of cover artwork
 | mini-media-player-progress-height | 6px | Progressbar height
+| mini-media-player-scale | 1 | Scale of the card
 
 
 ### Example usage

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -24,7 +24,7 @@ class MiniMediaPlayerButton extends LitElement {
       }
       :host([raised]) {
         background: rgba(255,255,255,0.25);
-        min-height: 36px;
+        min-height: calc(var(--mmp-unit) * .8);
         box-shadow:
           0px 3px 1px -2px rgba(0, 0, 0, 0.2),
           0px 2px 2px 0px rgba(0, 0, 0, 0.14),

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -91,11 +91,11 @@ class MiniMediaPlayerDropdown extends LitElement {
           font-size: 1em;
           justify-content: space-between;
           align-items: center;
-          height: 36px;
+          height: calc(var(--mmp-unit) - 4px);
           margin: 2px 0;
         }
         .mmp-dropdown__button.icon {
-          height: 40px;
+          height: var(--mmp-unit);
           margin: 0;
         }
         .mmp-dropdown__button > div {
@@ -103,7 +103,7 @@ class MiniMediaPlayerDropdown extends LitElement {
           flex: 1;
           justify-content: space-between;
           align-items: center;
-          height: 36px;
+          height: calc(var(--mmp-unit) - 4px);
           max-width: 100%;
         }
         .mmp-dropdown__label {
@@ -111,9 +111,9 @@ class MiniMediaPlayerDropdown extends LitElement {
           text-transform: none;
         }
         .mmp-dropdown__icon {
-          height: 24px;
-          width: 24px;
-          min-width: 24px;
+          height: calc(var(--mmp-unit) * .6);
+          width: calc(var(--mmp-unit) * .6);
+          min-width: calc(var(--mmp-unit) * .6);
         }
         paper-item > *:nth-child(2) {
           margin-left: 4px;

--- a/src/components/mediaControls.js
+++ b/src/components/mediaControls.js
@@ -169,6 +169,7 @@ class MiniMediaPlayerMediaControls extends LitElement {
         :host {
           display: flex;
           width: 100%;
+          justify-content: space-between;
         }
         .flex {
           display: flex;
@@ -181,20 +182,19 @@ class MiniMediaPlayerMediaControls extends LitElement {
           width: 100%;
         }
         paper-icon-button {
-          min-width: 40px;
+          min-width: var(--mmp-unit);
         }
         .mmp-media-controls__volume {
           flex: 100;
-          max-height: 40px;
+          max-height: var(--mmp-unit);
         }
         .mmp-media-controls__volume.--buttons {
           justify-content: left;
         }
         .mmp-media-controls__media {
-          justify-content: flex-end;
-          max-width: calc(40px * 4);
           margin-right: 0;
           margin-left: auto;
+          justify-content: inherit;
         }
         .mmp-media-controls__media[flow] {
           max-width: none;

--- a/src/components/powerstrip.js
+++ b/src/components/powerstrip.js
@@ -126,24 +126,25 @@ class MiniMediaPlayerPowerstrip extends LitElement {
       css`
         :host {
           display: flex;
-          line-height: 40px;
-          max-height: 40px;
+          line-height: var(--mmp-unit);
+          max-height: var(--mmp-unit);
         }
         :host([flow]) mmp-media-controls {
           max-width: unset;
         }
         mmp-media-controls {
-          max-width: 200px;
+          max-width: calc(var(--mmp-unit) * 5);
           line-height: initial;
+          justify-content: flex-end;
         }
         .group-button {
-          height: 34px;
-          width: 34px;
-          min-width: 34px;
+          height: calc(var(--mmp-unit) * .85);
+          width: calc(var(--mmp-unit) * .85);
+          min-width: calc(var(--mmp-unit) * .85);
           margin: 3px;
         }
         paper-icon-button {
-          min-width: 40px;
+          min-width: var(--mmp-unit);
         }
       `,
     ];

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -107,6 +107,7 @@ class MiniMediaPlayerShortcuts extends LitElement {
           justify-content: center;
           align-items: center;
           width: 100%;
+          padding: .2em 0;
         }
         .mmp-shortcuts__button > div[align='left'] {
           justify-content: flex-start;
@@ -130,8 +131,12 @@ class MiniMediaPlayerShortcuts extends LitElement {
           min-width: calc(16.66% - 8px);
         }
         .mmp-shortcuts__button > div > span {
-          line-height: 24px;
+          line-height: calc(var(--mmp-unit) * .6);
           text-transform: initial;
+        }
+        .mmp-shortcuts__button > div > iron-icon {
+          width: calc(var(--mmp-unit) * .6);
+          height: calc(var(--mmp-unit) * .6);
         }
         .mmp-shortcuts__button > div > *:nth-child(2) {
           margin-left: 4px;

--- a/src/components/soundMenu.js
+++ b/src/components/soundMenu.js
@@ -31,7 +31,7 @@ class MiniMediaPlayerSoundMenu extends LitElement {
         .label=${this.mode}
         .selected=${this.selected || this.mode}
         .icon=${this.icon}
-      />
+      ></mmp-dropdown>
     `;
   }
 
@@ -45,7 +45,7 @@ class MiniMediaPlayerSoundMenu extends LitElement {
     return css`
       :host {
         max-width: 120px;
-        min-width: 40px;
+        min-width: var(--mmp-unit);
       }
       :host([full]) {
         max-width: none;

--- a/src/components/sourceMenu.js
+++ b/src/components/sourceMenu.js
@@ -43,7 +43,7 @@ class MiniMediaPlayerSourceMenu extends LitElement {
     return css`
       :host {
         max-width: 120px;
-        min-width: 40px;
+        min-width: var(--mmp-unit);
       }
       :host([full]) {
         max-width: none;

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { LitElement, html } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map';
+import { styleMap } from 'lit-html/directives/style-map';
 import ResizeObserver from 'resize-observer-polyfill';
 import MediaPlayerObject from './model';
 import style from './style';
@@ -168,6 +169,7 @@ class MiniMediaPlayer extends LitElement {
     return html`
       <ha-card
         class=${this.computeClasses()}
+        style=${this.computeStyles()}
         @click=${e => this.handlePopup(e)}
         artwork=${config.artwork}
         content=${this.player.content}>
@@ -310,6 +312,13 @@ class MiniMediaPlayer extends LitElement {
       '--progress': this.player.hasProgress,
       '--runtime': !config.hide.runtime && this.player.hasProgress,
       '--inactive': !this.player.isActive,
+    });
+  }
+
+  computeStyles() {
+    const { scale } = this.config;
+    return styleMap({
+      ...(scale && { '--mmp-unit': `${40 * scale}px` }),
     });
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,7 @@ import { classMap } from 'lit-html/directives/class-map';
 import ResizeObserver from 'resize-observer-polyfill';
 import MediaPlayerObject from './model';
 import style from './style';
+import sharedStyle from './sharedStyle';
 import handleClick from './utils/handleClick';
 
 import './components/groupList';
@@ -57,7 +58,10 @@ class MiniMediaPlayer extends LitElement {
   }
 
   static get styles() {
-    return style;
+    return [
+      sharedStyle,
+      style,
+    ];
   }
 
   set hass(hass) {

--- a/src/sharedStyle.js
+++ b/src/sharedStyle.js
@@ -9,7 +9,13 @@ const sharedStyle = css`
   .label {
     margin: 0 8px;
   }
+  ha-icon {
+    width: calc(var(--mmp-unit) * .6);
+    height: calc(var(--mmp-unit) * .6);
+  }
   paper-icon-button {
+    width: var(--mmp-unit);
+    height: var(--mmp-unit);
     color: var(--mmp-text-color);
     transition: color .25s;
   }

--- a/src/style.js
+++ b/src/style.js
@@ -4,6 +4,8 @@ const style = css`
   :host {
     overflow: visible !important;
     display: block;
+    --mmp-unit: var(--mini-media-player-scale, 40px);
+    font-size: calc(var(--mmp-unit) * 0.35);
     --mmp-accent-color: var(--mini-media-player-accent-color, var(--accent-color, #f39c12));
     --mmp-base-color: var(--mini-media-player-base-color, var(--primary-text-color, #000));
     --mmp-overlay-color: var(--mini-media-player-overlay-color, rgba(0,0,0,0.5));
@@ -183,7 +185,7 @@ const style = css`
   }
   ha-card.--rtl .entity__info {
     margin-left: auto;
-    margin-right: 8px;
+    margin-right: calc(var(--mmp-unit) / 5);
   }
   ha-card[content='movie'] .attr__media_season,
   ha-card[content='movie'] .attr__media_episode {
@@ -198,11 +200,11 @@ const style = css`
     background-repeat: no-repeat;
     background-size: cover;
     border-radius: 100%;
-    height: 40px;
-    width: 40px;
-    min-width: 40px;
-    line-height: 40px;
-    margin-right: 8px;
+    height: var(--mmp-unit);
+    width: var(--mmp-unit);
+    min-width: var(--mmp-unit);
+    line-height: var(--mmp-unit);
+    margin-right: calc(var(--mmp-unit) / 5);
     position: relative;
     text-align: center;
     will-change: border-color;
@@ -228,7 +230,7 @@ const style = css`
     white-space: nowrap;
   }
   .entity__info__name {
-    line-height: 20px;
+    line-height: calc(var(--mmp-unit) / 2);
     color: var(--mmp-text-color);
   }
   .entity__info__media {
@@ -239,7 +241,7 @@ const style = css`
     transition: color .5s;
   }
   .entity__info__media[short] {
-    max-height: 20px;
+    max-height: calc(var(--mmp-unit) / 2);
     overflow: hidden;
   }
   .attr__app_name {
@@ -255,7 +257,7 @@ const style = css`
     opacity: .5;
   }
   .entity__info__media[short-scroll] {
-    max-height: 20px;
+    max-height: calc(var(--mmp-unit) / 2);
     white-space: nowrap;
   }
   .entity__info__media[scroll] > span {
@@ -296,12 +298,12 @@ const style = css`
     display: none;
   }
   .mmp-player__adds {
-    margin-left: 48px;
+    margin-left: calc(var(--mmp-unit) * 1.2);
     position: relative;
   }
   ha-card.--rtl .mmp-player__adds {
     margin-left: auto;
-    margin-right: 48px;
+    margin-right: calc(var(--mmp-unit) * 1.2);
   }
   .mmp-player__adds > *:nth-child(2) {
     margin-top: 0px;
@@ -316,7 +318,6 @@ const style = css`
   }
   mmp-media-controls {
     flex-wrap: wrap;
-    justify-content: center;
   }
   ha-card.--flow mmp-powerstrip {
     justify-content: space-between;

--- a/src/style.js
+++ b/src/style.js
@@ -4,8 +4,8 @@ const style = css`
   :host {
     overflow: visible !important;
     display: block;
-    --mmp-unit: var(--mini-media-player-scale, 40px);
-    font-size: calc(var(--mmp-unit) * 0.35);
+    --mmp-scale: var(--mini-media-player-scale, 1);
+    --mmp-unit: calc(var(--mmp-scale) * 40px);
     --mmp-accent-color: var(--mini-media-player-accent-color, var(--accent-color, #f39c12));
     --mmp-base-color: var(--mini-media-player-base-color, var(--primary-text-color, #000));
     --mmp-overlay-color: var(--mini-media-player-overlay-color, rgba(0,0,0,0.5));
@@ -54,6 +54,7 @@ const style = css`
     padding: 0;
     position: relative;
     color: inherit;
+    font-size: calc(var(--mmp-unit) * 0.35);
   }
   ha-card.--group {
     box-shadow: none;


### PR DESCRIPTION
Adds a new theme variable to adjust the scale of the card UI, this affects most of the cards elements and dimensions.

New theme variable is: `--mini-media-player-scale` and defaults to `40px`.
The value is basically the row height, each row of the card is allowed to take up this much height and the UI is scaled accordingly.

This variable can be set either in the user's theme which will apply it to all mmp cards or with card-mod in the `:host` selector to target individual cards.

![Screenshot 2019-11-13 at 18 54 27](https://user-images.githubusercontent.com/457678/68790176-16039680-0647-11ea-8cde-1976bf15afbf.png)


```yaml
# user-theme
mini-media-player-scale: 50px
```

```yaml
# card-mod example
...card config
style: |
  :host {
    --mini-media-player-scale: 50px;
  }
```

Unsure if we should add this as a card option instead of as a theme variable, and if we should keep the value as pixels or change it to percentage, scale (e.g. 2, 2.5, 0.75) or any other unit, would appreciate feedback regarding this.

Closes #156