### PR TITLE
adding image attribute for shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 |------|------|---------|-------------|
 | name | string | optional | A display name.
 | icon | string | optional | A display icon *(any mdi icon)*.
+| image | string | optional | A display image.
 | type | string | **required** | Type of shortcut. A media type: `music`, `tvshow`, `video`, `episode`, `channel`, `playlist` e.g. or an action type: `source`, `sound_mode`, `script` or `service`.
 | id | string | **required** | The media identifier. The format of this is component dependent. For example, you can provide URLs to Sonos & Cast but only a playlist ID to iTunes & Spotify. A source/(sound mode) name can also be specified to change source/(sound mode), use together with type `source`/`sound_mode`. If type `script` specify the script name here or `service` specify the `<domain>.<service>`.
 | data | list | optional | Extra service payload<sup>[1](#shortcut_foot1)</sup>.

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -58,6 +58,7 @@ class MiniMediaPlayerShortcuts extends LitElement {
             @click=${e => this.handleShortcut(e, item)}>
             <div align=${this.shortcuts.align_text}>
               ${item.icon ? html`<iron-icon .icon=${item.icon}></iron-icon>` : ''}
+              ${item.image ? html`<img src=${item.image}>` : ''}
               ${item.name ? html`<span class="ellipsis">${item.name}</span>` : ''}
             </div>
           </mmp-button>`)}
@@ -134,6 +135,9 @@ class MiniMediaPlayerShortcuts extends LitElement {
         }
         .mmp-shortcuts__button > div > *:nth-child(2) {
           margin-left: 4px;
+        }
+        .mmp-shortcuts__button > div > img {
+          height: 24px;
         }
       `,
     ];


### PR DESCRIPTION
I was missing the option to use a image on shortcut buttons. *(icons didn't cut it for me)*