### PR TITLE
Added note about type:service + spotcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,10 @@ You can specify media shortcuts through the `shortcuts` option, either as a list
           
       ... # etc.
 ```
-_If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service. Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) is required, for this to work. It's available in HACS.
+**Tip**:
+If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service.
+
+Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) is required, for this to work. It's available in HACS.
 
 #### Grouped cards
 Set the `group` option to `true` when nesting mini media player cards inside other cards that already have margins/paddings.

--- a/README.md
+++ b/README.md
@@ -279,17 +279,18 @@ You can specify media shortcuts through the `shortcuts` option, either as a list
       - icon: mdi:dog
         type: script
         id: script.script_name
-      - name: Crooners
+      # Trigger custom service
+      - name: Crooners Playlist
         type: service
         id: spotcast.start
-        data: {
-          "entity_id" : "media_player.googlehome1234",
-          "uri" : "spotify:playlist:37i9dQZF1DX9XiAcF7t1s5"
+        data:
+          entity_id: media_player.googlehome1234
+          uri: spotify:playlist:37i9dQZF1DX9XiAcF7t1s5
         }
 
       ... # etc.
 ```
-_If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service. Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) could be installed, for this to work. It's available in HACS.
+_If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service. Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) is required, for this to work. It's available in HACS.
 
 #### Grouped cards
 Set the `group` option to `true` when nesting mini media player cards inside other cards that already have margins/paddings.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ You can specify media shortcuts through the `shortcuts` option, either as a list
 **Tip**:
 If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service.
 
-Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) is required, for this to work. It's available in HACS.
+Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that the [spotcast](https://github.com/fondberg/spotcast) custom component is required, for this to work. It's available in HACS.
 
 #### Grouped cards
 Set the `group` option to `true` when nesting mini media player cards inside other cards that already have margins/paddings.

--- a/README.md
+++ b/README.md
@@ -279,8 +279,17 @@ You can specify media shortcuts through the `shortcuts` option, either as a list
       - icon: mdi:dog
         type: script
         id: script.script_name
+      - name: Crooners
+        type: service
+        id: spotcast.start
+        data: {
+          "entity_id" : "media_player.googlehome1234",
+          "uri" : "spotify:playlist:37i9dQZF1DX9XiAcF7t1s5"
+        }
+
       ... # etc.
 ```
+_If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service. Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) could be installed, for this to work. It's available in HACS.
 
 #### Grouped cards
 Set the `group` option to `true` when nesting mini media player cards inside other cards that already have margins/paddings.

--- a/README.md
+++ b/README.md
@@ -286,8 +286,7 @@ You can specify media shortcuts through the `shortcuts` option, either as a list
         data:
           entity_id: media_player.googlehome1234
           uri: spotify:playlist:37i9dQZF1DX9XiAcF7t1s5
-        }
-
+          
       ... # etc.
 ```
 _If you don't have Sonos, but want just a bit more control over playlists and so, a simple solution is to use the `type: service`-option, to trigger the`spotcast.start`-service. Remember to add the [required data](https://github.com/fondberg/spotcast#call-the-service), for spotcast to work. Also, kindly note that [spotcast](https://github.com/fondberg/spotcast) is required, for this to work. It's available in HACS.


### PR DESCRIPTION
I find it pretty difficult to spot the type:service option, and get it working with my Google Setup. I sadly wish to have Sonos around - however, with 6 Google devices, i'm not going to swap them, anytime soon.

So for everyon with Google, i guess this could be informative for other people, too.

Thanks for a great solution, btw :-) I guess you're taking my 1. place for the best custom module - that's for sure!