### PR TITLE
Resume progress tracking when re-connected #269

### DIFF
--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -113,8 +113,17 @@ class MiniMediaPlayerProgress extends LitElement {
   }
 
   disconnectedCallback() {
+    super.disconnectedCallback();
     this.resetSeek();
     clearInterval(this.tracker);
+    this.tracker = null;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    if (this.hasProgress) {
+      this.trackProgress();
+    }
   }
 
   calcProgress(x) {


### PR DESCRIPTION
Progress tracking did not resume correctly after card was brought into view after being in the background.

Closes: #269