### PR TITLE
New tts entity_id parameter to target speaker group #268

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 |------|------|---------|-------------|
 | platform | string | **required** | Specify [TTS platform](https://www.home-assistant.io/components/tts/), e.g. `google_translate` or `amazon_polly`, `alexa`<sup>[1](#tts_foot1)</sup> for ["Alexa as Media Player"](https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639), `ga`<sup>[2](#tts_foot2)</sup><sup>[3](#tts_foot3)</sup> for use with [Google Assistant Webserver](https://community.home-assistant.io/t/community-hass-io-add-on-google-assistant-webserver-broadcast-messages-without-interrupting-music/37274) or [Assistant Relay](https://github.com/greghesp/assistant-relay), `sonos`<sup>[2](#tts_foot2)</sup> for use with modified [sonos_say script](https://github.com/kalkih/mini-media-player/issues/86#issuecomment-465541825), `webos`<sup>[4](#tts_foot4)</sup>.
 | language | string | optional | The output language.
-| entity_id | string/list | optional | The *entity_id* of the desired output entity or a list of *entity_id's*, can also be `all` to broadcast to all entities.
+| entity_id | string/list | optional | The *entity_id* of the desired output entity or a list of *entity_id's*, can also be `all` to broadcast to all entities or `group` to target currently grouped speakers.
 | volume | float | optional | Volume level of tts output (0 - 1), only supported by platform `sonos`.
 | type | string | optional | `tts`, `announce` or `push`, defaults to `tts`, only supported by platform `alexa`, more info [here](https://github.com/keatontaylor/alexa_media_player/wiki/Notification-Component#functionality).
 

--- a/src/components/tts.js
+++ b/src/components/tts.js
@@ -7,6 +7,7 @@ class MiniMediaPlayerTts extends LitElement {
     return {
       hass: {},
       config: {},
+      player: {},
     };
   }
 
@@ -39,7 +40,8 @@ class MiniMediaPlayerTts extends LitElement {
     const { config, message } = this;
     const opts = {
       message,
-      entity_id: config.entity_id || this.entity,
+      entity_id: config.entity_id || this.player.id,
+      ...(config.entity_id === 'group' && { entity_id: this.player.group }),
     };
     if (config.language) opts.language = config.language;
     if (config.platform === 'alexa')

--- a/src/main.js
+++ b/src/main.js
@@ -209,7 +209,7 @@ class MiniMediaPlayer extends LitElement {
               <mmp-tts
                 .config=${config.tts}
                 .hass=${this.hass}
-                .entity=${this.player.id}>
+                .player=${this.player}>
               </mmp-tts>
             ` : ''}
             <mmp-group-list


### PR DESCRIPTION
Setting the tts `entity_id` to `group` will dynamically target the current speaker group for tts output.
```yaml
tts:
  entity_id: group
  ...
```
Closes: #268 