### PR TITLE
Options to hide previous and/or next playback controls #233

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | source | boolean | false | The source select.
 | sound_mode | boolean | true | The sound_mode select.
 | controls | boolean | false | The media playback controls.
+| prev | boolean | false | The "previous" playback control button.
+| next | boolean | false | The "next" playback control button.
 | play_pause | boolean | false | The play/pause button in media playback controls.
 | play_stop | boolean | true | The play/stop button in media playback controls.
 | volume | boolean | false | The volume controls.

--- a/src/components/mediaControls.js
+++ b/src/components/mediaControls.js
@@ -40,15 +40,17 @@ class MiniMediaPlayerMediaControls extends LitElement {
       ` : html``}
       ${!hide.controls ? html`
         <div class='flex mmp-media-controls__media' ?flow=${this.config.flow || this.break}>
-          <paper-icon-button
-            @click=${e => this.player.prev(e)}
-            .icon=${ICON.PREV}>
-          </paper-icon-button>
+          ${!hide.prev ? html`
+            <paper-icon-button
+              @click=${e => this.player.prev(e)}
+              .icon=${ICON.PREV}>
+            </paper-icon-button>` : ''}
           ${this.renderPlayButtons()}
-          <paper-icon-button
-            @click=${e => this.player.next(e)}
-            .icon=${ICON.NEXT}>
-          </paper-icon-button>
+          ${!hide.next ? html`
+            <paper-icon-button
+              @click=${e => this.player.next(e)}
+              .icon=${ICON.NEXT}>
+            </paper-icon-button>` : ''}
         </div>
       ` : html``}
     `;

--- a/src/const.js
+++ b/src/const.js
@@ -9,6 +9,8 @@ const DEFAULT_HIDE = {
   controls: false,
   play_pause: false,
   play_stop: true,
+  prev: false,
+  next: false,
 };
 const ICON = {
   DEFAULT: 'mdi:cast',


### PR DESCRIPTION
Adds `prev` & `next` hide options, to hide the previous and/or next playback button(s). 

Closes: #233 