### PR TITLE
Remove deprecated updating step

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,6 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
       type: module
   ```
 
-### *(Optional)* Add to custom updater
-
-1. Make sure you've the [custom_updater](https://github.com/custom-components/custom_updater) component installed and working.
-
-2. Add a new reference under `card_urls` in your `custom_updater` configuration in `configuration.yaml`.
-
-  ```yaml
-  custom_updater:
-    card_urls:
-      - https://raw.githubusercontent.com/kalkih/mini-media-player/master/tracker.json
-  ```
-
 ## Updating
 1. Find your `mini-media-player-bundle.js` file in `config/www` or wherever you ended up storing it.
 


### PR DESCRIPTION
Since custom updater has been deprecated for a long while it should be dropped.

HACS is highlighted at the top so I don't think this should cause an issue.