### PR TITLE
tts - google_translate platform issue

### DIFF
--- a/src/components/tts.js
+++ b/src/components/tts.js
@@ -58,6 +58,8 @@ class MiniMediaPlayerTts extends LitElement {
       this.hass.callService('notify', opts.entity_id.split('.').slice(-1)[0], { message });
     else if (config.platform === 'ga')
       this.hass.callService('notify', 'ga_broadcast', { message });
+    else if (config.platform === 'google_translate')
+      this.hass.callService('tts', `google_say`, opts);
     else
       this.hass.callService('tts', `${config.platform}_say`, opts);
     e.stopPropagation();


### PR DESCRIPTION
The else path in line `this.hass.callService('tts', `${config.platform}_say`, opts);` is resulting in the service `tts\google_translate_say` being called if the platform is google_translate which does not work. I believe the correct service to call for tts is `tts\google_say` and it works when I change the code locally. Code has been modified to reflect to add a new `else if` path if the platform is google_translate.