### PR TITLE
Add volume step control to volume buttons v2

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,7 +9,6 @@ rules:
   no-mixed-operators: 0
   class-methods-use-this: 0
   no-nested-ternary: 0
-  linebreak-style: 0
 globals:
   window: true
   Event: true

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,6 +9,7 @@ rules:
   no-mixed-operators: 0
   class-methods-use-this: 0
   no-nested-ternary: 0
+  linebreak-style: 0
 globals:
   window: true
   Event: true

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 | sound_mode | string | optional | v1.1.2 | Change sound mode select appearance, `icon` for just an icon, `full` for the full sound mode name.
 | info | string | optional | v1.0.0 | Change how the media information is displayed, `short` to limit media information to one row, `scroll` to scroll overflowing media info.
 | volume_stateless | boolean | false | v0.6 | Swap out the volume slider for volume up & down buttons.
-| volume_step | string | 10 | v1.9.0 | Change the volume step size of volume buttons.
+| volume_step | number | optional | v1.9.0 | Change the volume step size of volume buttons (number between 1 - 100).
 | max_volume | number | optional | v0.8.2 | Specify the max vol limit of the volume slider (number between 1 - 100).
 | min_volume | number | optional | v1.1.2 | Specify the min vol limit of the volume slider (number between 1 - 100).
 | replace_mute | string | optional | v0.9.8 | Replace the mute button, available options are `play_pause` (previously `play`), `stop`, `play_stop`, `next`.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 | sound_mode | string | optional | v1.1.2 | Change sound mode select appearance, `icon` for just an icon, `full` for the full sound mode name.
 | info | string | optional | v1.0.0 | Change how the media information is displayed, `short` to limit media information to one row, `scroll` to scroll overflowing media info.
 | volume_stateless | boolean | false | v0.6 | Swap out the volume slider for volume up & down buttons.
+| volume_step | string | 10 | v1.9.0 | Change the volume step size of volume buttons.
 | max_volume | number | optional | v0.8.2 | Specify the max vol limit of the volume slider (number between 1 - 100).
 | min_volume | number | optional | v1.1.2 | Specify the min vol limit of the volume slider (number between 1 - 100).
 | replace_mute | string | optional | v0.9.8 | Replace the mute button, available options are `play_pause` (previously `play`), `stop`, `play_stop`, `next`.

--- a/src/main.js
+++ b/src/main.js
@@ -119,6 +119,7 @@ class MiniMediaPlayer extends LitElement {
       source: 'default',
       sound_mode: 'default',
       toggle_power: true,
+      volume_step: 10,
       tap_action: {
         action: 'more-info',
       },

--- a/src/main.js
+++ b/src/main.js
@@ -119,7 +119,7 @@ class MiniMediaPlayer extends LitElement {
       source: 'default',
       sound_mode: 'default',
       toggle_power: true,
-      volume_step: 10,
+      volume_step: null,
       tap_action: {
         action: 'more-info',
       },

--- a/src/model.js
+++ b/src/model.js
@@ -260,7 +260,7 @@ export default class MediaPlayerObject {
   }
 
   volumeUp(e) {
-    if (this.supportsVolumeSet) {
+    if (this.supportsVolumeSet && this.config.volume_step > 0) {
       this.callService(e, 'volume_set', {
         entity_id: this.config.entity,
         volume_level: Math.min(this.vol + this.config.volume_step / 100, 1),
@@ -269,7 +269,7 @@ export default class MediaPlayerObject {
   }
 
   volumeDown(e) {
-    if (this.supportsVolumeSet) {
+    if (this.supportsVolumeSet && this.config.volume_step > 0) {
       this.callService(e, 'volume_set', {
         entity_id: this.config.entity,
         volume_level: Math.max(this.vol - this.config.volume_step / 100, 0),

--- a/src/model.js
+++ b/src/model.js
@@ -186,6 +186,10 @@ export default class MediaPlayerObject {
     return !(typeof this.attr.is_volume_muted === 'undefined');
   }
 
+  get supportsVolumeSet() {
+    return !(typeof this.attr.volume_level === 'undefined');
+  }
+
   getAttribute(attribute) {
     return this.attr[attribute] || '';
   }
@@ -256,11 +260,21 @@ export default class MediaPlayerObject {
   }
 
   volumeUp(e) {
-    this.callService(e, 'volume_up');
+    if (this.supportsVolumeSet) {
+      this.callService(e, 'volume_set', {
+        entity_id: this.config.entity,
+        volume_level: this.vol + this.config.volume_step / 100,
+      });
+    } else this.callService(e, 'volume_up');
   }
 
   volumeDown(e) {
-    this.callService(e, 'volume_down');
+    if (this.supportsVolumeSet) {
+      this.callService(e, 'volume_set', {
+        entity_id: this.config.entity,
+        volume_level: this.vol - this.config.volume_step / 100,
+      });
+    } else this.callService(e, 'volume_down');
   }
 
   seek(e, pos) {

--- a/src/model.js
+++ b/src/model.js
@@ -263,7 +263,7 @@ export default class MediaPlayerObject {
     if (this.supportsVolumeSet) {
       this.callService(e, 'volume_set', {
         entity_id: this.config.entity,
-        volume_level: this.vol + this.config.volume_step / 100,
+        volume_level: Math.min(this.vol + this.config.volume_step / 100, 1),
       });
     } else this.callService(e, 'volume_up');
   }
@@ -272,7 +272,7 @@ export default class MediaPlayerObject {
     if (this.supportsVolumeSet) {
       this.callService(e, 'volume_set', {
         entity_id: this.config.entity,
-        volume_level: this.vol - this.config.volume_step / 100,
+        volume_level: Math.max(this.vol - this.config.volume_step / 100, 0),
       });
     } else this.callService(e, 'volume_down');
   }


### PR DESCRIPTION
Digged deeper into the HA core media player. As [volume_set service gets the volume_level float](https://github.com/home-assistant/core/blob/8cd905487e482e874a384c2e8a02070a53adfb95/homeassistant/components/media_player/__init__.py#L259) I assume it as the same behavior as the [check for mute support](https://github.com/kalkih/mini-media-player/blob/4925a6b7ccbb3da528f4d9fc870abf78e7b3834b/src/model.js#L185)
Then this should be the better version compared to #291 