### PR TITLE
Squeezebox multiroom support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,21 +128,22 @@ See [Speaker group management](#speaker-group-management) for example usage.
 **Supported platforms**
 - sonos
 - soundtouch
-- yamaha_musiccast<sup>[1](#speaker_foot1)</sup>
+- squeezebox<sup>[2](#speaker_foot2)</sup>
 - bluesound<sup>[2](#speaker_foot2)</sup>
 - snapcast<sup>[2](#speaker_foot2)</sup>
+- yamaha_musiccast<sup>[1](#speaker_foot1)</sup>
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
 | entities | list | **required** | A list containing [speaker entities](#speaker-entity-object) of one of supported platforms, to enable group management of those speakers.
-| platform | string | 'sonos' | The media_player platform to control. `sonos`, `soundtouch`, `snapcast`, `bluesound` or `yamaha_musiccast`<sup>[1](#speaker_foot1)</sup>.
+| platform | string | 'sonos' | The media_player platform to control. `sonos`, `soundtouch`, `snapcast`, `bluesound`, `squeezebox` or `yamaha_musiccast`<sup>[1](#speaker_foot1)</sup>.
 | sync_volume | boolean | optional | Keep volume Synchronize between grouped speakers.
 | expanded | boolean | optional | Make the speaker group list expanded by default.
 | show_group_count | boolean | true | Have the number of grouped speakers displayed (if any) in the card name.
 | icon | string | optional | Override default group button icon *(any mdi icon)*.
 
 <a name="speaker_foot1"><sup>1</sup></a> Currently not yet supported in Home Assistant, *soon™*
-<a name="speaker_foot2"><sup>2</sup></a> Some features are not yet supported.
+<a name="speaker_foot2"><sup>2</sup></a> All features are not yet supported.
 
 #### Speaker entity object
 | Name | Type | Default | Description |

--- a/src/const.js
+++ b/src/const.js
@@ -55,6 +55,9 @@ const MEDIA_INFO = [
   { attr: 'app_name' },
 ];
 
+const PLATFORM = {
+  SQUEEZEBOX: 'squeezebox',
+}
 
 export {
   DEFAULT_HIDE,
@@ -64,4 +67,5 @@ export {
   BREAKPOINT,
   LABEL_SHORTCUT,
   MEDIA_INFO,
+  PLATFORM,
 };

--- a/src/const.js
+++ b/src/const.js
@@ -56,8 +56,11 @@ const MEDIA_INFO = [
 ];
 
 const PLATFORM = {
+  SONOS: 'sonos',
   SQUEEZEBOX: 'squeezebox',
-}
+  BLUESOUND: 'bluesound',
+  SOUNDTOUCH: 'soundtouch',
+};
 
 export {
   DEFAULT_HIDE,

--- a/src/model.js
+++ b/src/model.js
@@ -82,8 +82,10 @@ export default class MediaPlayerObject {
   }
 
   get group() {
-    const groupName = `${this.platform}_group`;
-    return this.attr[groupName] || [];
+    if (this.platform === PLATFORM.SQUEEZEBOX) {
+      return this.attr.sync_group || [];
+    }
+    return this.attr[`${this.platform}_group`] || [];
   }
 
   get platform() {

--- a/src/model.js
+++ b/src/model.js
@@ -1,4 +1,4 @@
-import { PROGRESS_PROPS, MEDIA_INFO } from './const';
+import { PROGRESS_PROPS, MEDIA_INFO, PLATFORM } from './const';
 
 export default class MediaPlayerObject {
   constructor(hass, config, entity) {
@@ -82,12 +82,18 @@ export default class MediaPlayerObject {
   }
 
   get group() {
-    const groupName = `${this.config.speaker_group.platform}_group`;
+    const groupName = `${this.platform}_group`;
     return this.attr[groupName] || [];
   }
 
+  get platform() {
+    return this.config.speaker_group.platform;
+  }
+
   get master() {
-    return this.group[0] || this.config.entity;
+    return this.supportsMaster
+      ? this.group[0] || this.config.entity
+      : this.config.entity;
   }
 
   get isMaster() {
@@ -190,12 +196,16 @@ export default class MediaPlayerObject {
     return !(typeof this.attr.volume_level === 'undefined');
   }
 
-  getAttribute(attribute) {
-    return this.attr[attribute] || '';
+  get supportsMaster() {
+    return this.platform !== PLATFORM.SQUEEZEBOX;
   }
 
   get artwork() {
     return `url(${this.attr.entity_picture_local ? this.hass.hassUrl(this.picture) : this.picture})`;
+  }
+
+  getAttribute(attribute) {
+    return this.attr[attribute] || '';
   }
 
   toggle(e) {


### PR DESCRIPTION
Squeezebox doesn't have a slave/master setup like many other platforms so it requires some changes related to that functionality, now we set the card entity as the master, I'm not sure if this is the best solution.
Also, the service calls it uses are not the "standardized" ones, and there doesn't seem to be support for grouping multiple entities at once, at least not from looking at the documentation.
https://www.home-assistant.io/integrations/squeezebox/

Need to add documentation.