### PR TITLE
Shortcut cover image #236

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | name | string | optional | A display name.
 | icon | string | optional | A display icon *(any mdi icon)*.
 | image | string | optional | A display image.
+| cover | string | optional | A cover image (only supported for button shortcuts).
 | type | string | **required** | Type of shortcut. A media type: `music`, `tvshow`, `video`, `episode`, `channel`, `playlist` e.g. or an action type: `source`, `sound_mode`, `script` or `service`.
 | id | string | **required** | The media identifier. The format of this is component dependent. For example, you can provide URLs to Sonos & Cast but only a playlist ID to iTunes & Spotify. A source/(sound mode) name can also be specified to change source/(sound mode), use together with type `source`/`sound_mode`. If type `script` specify the script name here or `service` specify the `<domain>.<service>`.
 | data | list | optional | Extra service payload<sup>[1](#shortcut_foot1)</sup>.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   "author": "Karl Kihlström <mrkihlstrom@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "lit-element": "^2.2.1",
-    "lit-html": "^1.1.2",
+    "lit-element": "^2.3.1",
+    "lit-html": "^1.2.1",
     "resize-observer-polyfill": "^1.5.1"
   },
   "devDependencies": {

--- a/src/components/shortcuts.js
+++ b/src/components/shortcuts.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit-element';
+import { styleMap } from 'lit-html/directives/style-map';
 
 import './dropdown';
 import './button';
@@ -50,7 +51,7 @@ class MiniMediaPlayerShortcuts extends LitElement {
       <div class='mmp-shortcuts__buttons'>
         ${this.buttons.map(item => html`
           <mmp-button
-            style=${`min-height: ${this.height}px;`}
+            style="${styleMap(this.shortcutStyle(item))}"
             raised
             columns=${this.shortcuts.columns}
             ?color=${item.id === active}
@@ -88,6 +89,13 @@ class MiniMediaPlayerShortcuts extends LitElement {
     this.player.setMedia(ev, options);
   }
 
+  shortcutStyle(item) {
+    return {
+      'min-height': `${this.height}px;`,
+      ...(item.cover && { 'background-image': `url(${item.cover})` }),
+    };
+  }
+
   static get styles() {
     return [
       sharedStyle,
@@ -101,6 +109,9 @@ class MiniMediaPlayerShortcuts extends LitElement {
         .mmp-shortcuts__button {
           min-width: calc(50% - 8px);
           flex: 1;
+          background-size: cover;
+          background-repeat: no-repeat;
+          background-position: center center;
         }
         .mmp-shortcuts__button > div {
           display: flex;


### PR DESCRIPTION
Adds a cover option for shortcut items.

```yaml
shortcuts:
  buttons:
    - name: example
      cover: /local/images/bg-example.jpg
    ...
```

closes #236