### PR TITLE
Fetch artwork & save in base64 before rendering it

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,3 +14,5 @@ globals:
   Event: true
   customElements: true
   CustomEvent: true
+  fetch: true
+  Request: true

--- a/src/const.js
+++ b/src/const.js
@@ -38,7 +38,7 @@ const ICON = {
   VOL_UP: 'mdi:volume-plus',
 };
 const UPDATE_PROPS = ['entity', '_overflow',
-  'break', 'thumbnail', 'edit', 'idle'];
+  'break', 'thumbnail', 'prevThumbnail', 'edit', 'idle'];
 
 const PROGRESS_PROPS = ['media_duration', 'media_position', 'media_position_updated_at'];
 

--- a/src/main.js
+++ b/src/main.js
@@ -338,10 +338,14 @@ class MiniMediaPlayer extends LitElement {
     });
   }
 
-  computeArtwork() {
+  async computeArtwork() {
     const { picture, hasArtwork } = this.player;
     if (hasArtwork && picture !== this.picture) {
-      this.thumbnail = this.player.artwork;
+      try {
+        this.thumbnail = await this.player.fetchArtwork();
+      } catch (error) {
+        this.thumbnail = '';
+      }
       this.picture = picture;
     }
     return !!(hasArtwork && this.thumbnail);

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,8 @@ class MiniMediaPlayer extends LitElement {
     this._overflow = false;
     this.initial = true;
     this.picture = false;
-    this.thumbnail = false;
+    this.thumbnail = '';
+    this.prevThumbnail = '';
     this.edit = false;
     this.rtl = false;
   }
@@ -66,6 +67,7 @@ class MiniMediaPlayer extends LitElement {
       initial: Boolean,
       picture: String,
       thumbnail: String,
+      prevThumbnail: String,
       edit: Boolean,
       rtl: Boolean,
       idle: Boolean,
@@ -147,6 +149,11 @@ class MiniMediaPlayer extends LitElement {
 
   shouldUpdate(changedProps) {
     if (this.break === undefined) this.computeRect(this);
+    if (changedProps.has('prevThumbnail') && this.prevThumbnail) {
+      setTimeout(() => {
+        this.prevThumbnail = '';
+      }, 1000);
+    }
     return UPDATE_PROPS.some(prop => changedProps.has(prop)) && this.player;
   }
 
@@ -255,7 +262,9 @@ class MiniMediaPlayer extends LitElement {
       ? `url(${this.config.background})`
       : this.thumbnail;
 
-    return html`<div class='cover' style='background-image: ${url};'></div>`;
+    return html`
+      <div class='cover' style='background-image: ${url};'></div>
+      ${this.prevThumbnail && html`<div class='cover --prev' style='background-image: ${this.prevThumbnail};'></div>`}`;
   }
 
   handlePopup(e) {
@@ -341,12 +350,16 @@ class MiniMediaPlayer extends LitElement {
   async computeArtwork() {
     const { picture, hasArtwork } = this.player;
     if (hasArtwork && picture !== this.picture) {
+      this.picture = picture;
       try {
-        this.thumbnail = await this.player.fetchArtwork();
+        const artwork = await this.player.fetchArtwork();
+        if (this.thumbnail) {
+          this.prevThumbnail = this.thumbnail;
+        }
+        this.thumbnail = artwork;
       } catch (error) {
         this.thumbnail = '';
       }
-      this.picture = picture;
     }
     return !!(hasArtwork && this.thumbnail);
   }

--- a/src/model.js
+++ b/src/model.js
@@ -1,4 +1,5 @@
 import { PROGRESS_PROPS, MEDIA_INFO, PLATFORM } from './const';
+import arrayBufferToBase64 from './utils/misc';
 
 export default class MediaPlayerObject {
   constructor(hass, config, entity) {
@@ -202,8 +203,18 @@ export default class MediaPlayerObject {
     return this.platform !== PLATFORM.SQUEEZEBOX;
   }
 
-  get artwork() {
-    return `url(${this.attr.entity_picture_local ? this.hass.hassUrl(this.picture) : this.picture})`;
+  async fetchArtwork() {
+    const url = this.attr.entity_picture_local ? this.hass.hassUrl(this.picture) : this.picture;
+
+    try {
+      const res = await fetch(new Request(url));
+      const buffer = await res.arrayBuffer();
+      const image64 = arrayBufferToBase64(buffer);
+      const imageType = res.headers.get('Content-Type') || 'image/jpeg';
+      return `url(data:${imageType};base64,${image64})`;
+    } catch (error) {
+      return false;
+    }
   }
 
   getAttribute(attribute) {

--- a/src/style.js
+++ b/src/style.js
@@ -129,6 +129,10 @@ const style = css`
     transition: opacity .75s cubic-bezier(.21,.61,.35,1);
     will-change: opacity;
   }
+  .cover:before {
+    content: '';
+    background: var(--mmp-overlay-color);
+  }
   .cover {
     animation: fade-in .5s cubic-bezier(.21,.61,.35,1);
     background-size: cover;
@@ -137,9 +141,8 @@ const style = css`
     border-radius: var(--ha-card-border-radius, 0);
     overflow: hidden;
   }
-  .cover:before {
-    background: var(--mmp-overlay-color);
-    content: '';
+  .cover.--prev {
+    animation: fade-in .5s linear reverse forwards;
   }
   ha-card[artwork*='full-cover'].--has-artwork .mmp-player {
     background: linear-gradient(to top, var(--mmp-overlay-color) var(--mmp-overlay-color-stop), transparent 100%);

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,0 +1,10 @@
+const arrayBufferToBase64 = (buffer) => {
+  let binary = '';
+  const bytes = [].slice.call(new Uint8Array(buffer));
+
+  bytes.forEach(b => binary += String.fromCharCode(b));
+
+  return window.btoa(binary);
+};
+
+export default arrayBufferToBase64;


### PR DESCRIPTION
Fetch image artwork & save in Base64, use base64 image in rendering.
This prevents unwanted black / flickering / abrupt clearing artwork while it's loading.

Fixes #321