### PR TITLE
Fixed dropdown icon

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -50,7 +50,7 @@ class MiniMediaPlayerDropdown extends LitElement {
               <span class='mmp-dropdown__label ellipsis'>
                 ${this.selected || this.label}
               </span>
-              <ha-icon class='mmp-dropdown__icon' .icon=${ICON.DROPDOWN}></ha-icon>
+              <ha-icon class='mmp-dropdown__button icon' .icon=${ICON.DROPDOWN}></ha-icon>
             </div>
           </mmp-button>
         `}


### PR DESCRIPTION
Saw recently that fixes went in to fix icon alignment post 0.110, but I've been having issues with my setup still - realised after some digging today that it only shows when the Source is shown next to the icon

This changes the class for the full size source selector which allows it to be center aligned vertically

