### PR TITLE
Artowork relative url fallback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -363,7 +363,7 @@ class MiniMediaPlayer extends LitElement {
         }
         this.thumbnail = artwork;
       } catch (error) {
-        this.thumbnail = '';
+        this.thumbnail = `url(${picture})`;
       }
     }
     return !!(hasArtwork && this.thumbnail);


### PR DESCRIPTION
Add a fallback to the image url when failing fetching base64 image data

Resolves #385