### PR TITLE
Fix progress display for mpd

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -67,6 +67,10 @@ export default class MediaPlayerObject {
   }
 
   get position() {
+    if (typeof this.attr.media_position === 'string') {
+      // mpd provides media_position as 'position:duration'
+      return Number(this.attr.media_position.split(':')[0]) || 0;
+    }
     return this.attr.media_position || 0;
   }
 


### PR DESCRIPTION
As described in https://github.com/kalkih/mini-media-player/issues/269#issuecomment-610862239 progress display is broken when using MPD.

MPD provides the `media_position` attribute as `position:duration` so the actual position has to be extracted and converted to a number.

For now the additional parsing is done implicitly each time the position is a string.
This shouldn't break even if there is no `:` in the string, but maybe it would be a good idea to explicitly check if the platform is MPD? 