### PR TITLE
Fix artwork fallback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -356,17 +356,12 @@ class MiniMediaPlayer extends LitElement {
     const { picture, hasArtwork } = this.player;
     if (hasArtwork && picture !== this.picture) {
       this.picture = picture;
-      try {
-        const artwork = await this.player.fetchArtwork();
-        if (this.thumbnail) {
-          this.prevThumbnail = this.thumbnail;
-        }
-        this.thumbnail = artwork;
-      } catch (error) {
-        this.thumbnail = `url(${picture})`;
+      const artwork = await this.player.fetchArtwork();
+      if (this.thumbnail) {
+        this.prevThumbnail = this.thumbnail;
       }
+      this.thumbnail = artwork ? artwork : `url(${picture})`;
     }
-    return !!(hasArtwork && this.thumbnail);
   }
 
   computeIcon() {


### PR DESCRIPTION
Update fallback logic to actually work.
`player.fetchArtwork` returns false instead of throwing error.

This happens to me when it's an external url which doesn't support CORS. I get a fetch error and then nothing happens.

It looks like the return value isn't used anymore so I removed that too.