### PR TITLE
Support for alternative current entity for groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ See [Speaker group management](#speaker-group-management) for example usage.
 | expanded | boolean | optional | Make the speaker group list expanded by default.
 | show_group_count | boolean | true | Have the number of grouped speakers displayed (if any) in the card name.
 | icon | string | optional | Override default group button icon *(any mdi icon)*.
+| real_player | string | optional | Override the player entity for the group management (Usefull if you use a universal media_player as your entity but still want to use the grouping feature)
 
 <a name="speaker_foot1"><sup>1</sup></a> Requires [custom component](https://github.com/ppanagiotis/pymusiccast), available in HACS.
 
@@ -306,7 +307,7 @@ You can specify media shortcuts through the `shortcuts` option, either as a list
         data:
           entity_id: media_player.googlehome1234
           uri: spotify:playlist:37i9dQZF1DX9XiAcF7t1s5
-          
+
       ... # etc.
 ```
 **Tip**:

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See [Speaker group management](#speaker-group-management) for example usage.
 | expanded | boolean | optional | Make the speaker group list expanded by default.
 | show_group_count | boolean | true | Have the number of grouped speakers displayed (if any) in the card name.
 | icon | string | optional | Override default group button icon *(any mdi icon)*.
-| group_mgmt_entity | string | optional | Override the player entity for the group management (Usefull if you use a universal media_player as your entity but still want to use the grouping feature)
+| group_mgmt_entity | string | optional | Override the player entity for the group management (Useful if you use a universal media_player as your entity but still want to use the grouping feature)
 
 <a name="speaker_foot1"><sup>1</sup></a> Requires [custom component](https://github.com/ppanagiotis/pymusiccast), available in HACS.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ See [Speaker group management](#speaker-group-management) for example usage.
 | expanded | boolean | optional | Make the speaker group list expanded by default.
 | show_group_count | boolean | true | Have the number of grouped speakers displayed (if any) in the card name.
 | icon | string | optional | Override default group button icon *(any mdi icon)*.
-| real_player | string | optional | Override the player entity for the group management (Usefull if you use a universal media_player as your entity but still want to use the grouping feature)
+| group_mgmt_entity | string | optional | Override the player entity for the group management (Usefull if you use a universal media_player as your entity but still want to use the grouping feature)
 
 <a name="speaker_foot1"><sup>1</sup></a> Requires [custom component](https://github.com/ppanagiotis/pymusiccast), available in HACS.
 

--- a/src/const.js
+++ b/src/const.js
@@ -39,7 +39,7 @@ const ICON = {
   VOL_UP: 'mdi:volume-plus',
 };
 
-const UPDATE_PROPS = ['entity', '_overflow',
+const UPDATE_PROPS = ['entity', 'groupMgmtEntity', '_overflow',
   'break', 'thumbnail', 'prevThumbnail', 'edit', 'idle', 'cardHeight', 'backgroundColor', 'foregroundColor'];
 
 const PROGRESS_PROPS = ['media_duration', 'media_position', 'media_position_updated_at'];

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,7 @@ class MiniMediaPlayer extends LitElement {
       config: {},
       entity: {},
       player: {},
+      groupMgmtEntity: {},
       groupMgmtPlayer: MediaPlayerObject,
       _overflow: Boolean,
       break: Boolean,
@@ -83,7 +84,10 @@ class MiniMediaPlayer extends LitElement {
     }
     if (this.config && this.config.speaker_group && this.config.speaker_group.group_mgmt_entity) {
       const altPlayer = hass.states[this.config.speaker_group.group_mgmt_entity];
-      this.groupMgmtPlayer = new MediaPlayerObject(hass, this.config, altPlayer);
+      if (altPlayer && this.groupMgmtPlayer !== altPlayer) {
+        this.groupMgmtEntity = altPlayer;
+        this.groupMgmtPlayer = new MediaPlayerObject(hass, this.config, altPlayer);
+      }
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -47,7 +47,7 @@ class MiniMediaPlayer extends LitElement {
       config: {},
       entity: {},
       player: {},
-      realPlayer: MediaPlayerObject,
+      groupMgmtPlayer: MediaPlayerObject,
       _overflow: Boolean,
       break: Boolean,
       initial: Boolean,
@@ -81,9 +81,9 @@ class MiniMediaPlayer extends LitElement {
       this.idle = this.player.idle;
       if (this.player.trackIdle) this.updateIdleStatus();
     }
-    if (this.config && this.config.speaker_group && this.config.speaker_group.real_player) {
-      const realPlayer = hass.states[this.config.speaker_group.real_player];
-      this.realPlayer = new MediaPlayerObject(hass, this.config, realPlayer);
+    if (this.config && this.config.speaker_group && this.config.speaker_group.group_mgmt_entity) {
+      const altPlayer = hass.states[this.config.speaker_group.group_mgmt_entity];
+      this.groupMgmtPlayer = new MediaPlayerObject(hass, this.config, altPlayer);
     }
   }
 
@@ -205,7 +205,7 @@ class MiniMediaPlayer extends LitElement {
               .hass=${this.hass}
               .visible=${this.edit}
               .entities=${config.speaker_group.entities}
-              .player=${this.realPlayer ? this.realPlayer : this.player}>
+              .player=${this.groupMgmtPlayer ? this.groupMgmtPlayer : this.player}>>
             </mmp-group-list>
           </div>
         </div>
@@ -334,7 +334,8 @@ class MiniMediaPlayer extends LitElement {
 
   speakerCount() {
     if (this.config.speaker_group.show_group_count) {
-      const count = this.realPlayer ? this.realPlayer.groupCount : this.player.groupCount;
+      const count = this.groupMgmtPlayer
+        ? this.groupMgmtPlayer.groupCount : this.player.groupCount;
       return count > 1 ? ` +${count - 1}` : '';
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,7 @@ class MiniMediaPlayer extends LitElement {
       config: {},
       entity: {},
       player: {},
+      realPlayer: MediaPlayerObject,
       _overflow: Boolean,
       break: Boolean,
       initial: Boolean,
@@ -79,6 +80,10 @@ class MiniMediaPlayer extends LitElement {
       this.rtl = this.computeRTL(hass);
       this.idle = this.player.idle;
       if (this.player.trackIdle) this.updateIdleStatus();
+    }
+    if (this.config && this.config.speaker_group && this.config.speaker_group.real_player) {
+      const realPlayer = hass.states[this.config.speaker_group.real_player];
+      this.realPlayer = new MediaPlayerObject(hass, this.config, realPlayer);
     }
   }
 
@@ -200,7 +205,7 @@ class MiniMediaPlayer extends LitElement {
               .hass=${this.hass}
               .visible=${this.edit}
               .entities=${config.speaker_group.entities}
-              .player=${this.player}>
+              .player=${this.realPlayer ? this.realPlayer : this.player}>
             </mmp-group-list>
           </div>
         </div>
@@ -329,7 +334,7 @@ class MiniMediaPlayer extends LitElement {
 
   speakerCount() {
     if (this.config.speaker_group.show_group_count) {
-      const count = this.player.groupCount;
+      const count = this.realPlayer ? this.realPlayer.groupCount : this.player.groupCount;
       return count > 1 ? ` +${count - 1}` : '';
     }
   }


### PR DESCRIPTION
I have a universal media_player which is setup with a sonos connect and external volume control (external amp).
In this case, it's not possible to benefit from the grouping feature offered by mmp. 

This PR introduces a new `real_player` parameter in the `speaker_group` object. If defined, it overrides the `entity` for everything related to group management.

This will work properly once #418 is fixed. (tested using the forked version on which I applied some fixes see https://github.com/mcguiresean/mini-media-player/pull/1)

Feedback appreciated :) (PR seems ugly though...)