### PR TITLE
Changed yamaha_musiccast to musiccast_yamaha

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ See [Speaker group management](#speaker-group-management) for example usage.
 - squeezebox<sup>[2](#speaker_foot2)</sup>
 - bluesound<sup>[2](#speaker_foot2)</sup>
 - snapcast<sup>[2](#speaker_foot2)</sup>
-- yamaha_musiccast<sup>[1](#speaker_foot1)</sup>
+- musiccast_yamaha<sup>[1](#speaker_foot1)</sup>
 - linkplay<sup>[3](#speaker_foot3)</sup>
 
 | Name | Type | Default | Description |


### PR DESCRIPTION
The custom integration that supports groups is called musiccast_yamaha. Changed the documentation to reflect that.