### PR TITLE
Remove idle_view from UI editor

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -235,12 +235,6 @@ export default class MiniMediaPlayerEditor extends LitElement {
           </div>
 
           <div class="side-by-side">
-            <paper-input
-              label="Idle View"
-              .value="${this._config.idle_view}"
-              .configValue="${'idle_view'}"
-              @value-changed=${this.valueChanged}
-            ></paper-input>
 
             <paper-input
               label="Background"


### PR DESCRIPTION
Remove `idle_view` option from card editor as it's miss configured and doesn't function properly.
Fixes: #468, #478