### PR TITLE
Added artwork setting option to scale YouTube Music images correctly

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -18,6 +18,7 @@ const OptionsArtwork = [
   'cover',
   'full-cover',
   'material',
+  'youtube-music-cover',
   'cover-fit',
   'none',
 ];

--- a/src/main.js
+++ b/src/main.js
@@ -258,10 +258,12 @@ class MiniMediaPlayer extends LitElement {
       backgroundImage: this.thumbnail,
       backgroundColor: this.backgroundColor || '',
       width: this.config.artwork === 'material' && this.player.isActive ? `${this.cardHeight}px` : '100%',
+      transform: this.config.artwork === 'youtube-music-cover' ? 'scale(1.777777777777778)' : 'none',
     };
     const artworkPrevStyle = {
       backgroundImage: this.prevThumbnail,
       width: this.config.artwork === 'material' ? `${this.cardHeight}px` : '',
+      transform: this.config.artwork === 'youtube-music-cover' ? 'scale(1.777777777777778)' : 'none',
     };
 
     return html`


### PR DESCRIPTION
YouTube Music has album art 480px wide.
But there are borders on top and on the sided.
The actual album art is 270px.
That's a factor of 1.777777777777778.
By adding a tansform to scale the image by that factor the album art looks like cover should look.