### PR TITLE
Do not increment progress if player isn't playing

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -164,7 +164,7 @@ export default class MediaPlayerObject {
   }
 
   get progress() {
-    return this.position + (Date.now() - new Date(this.updatedAt).getTime()) / 1000.0;
+    return this.position + this.isPlaying ? (Date.now() - new Date(this.updatedAt).getTime()) / 1000.0 : 0.0;
   }
 
   get idleView() {

--- a/src/model.js
+++ b/src/model.js
@@ -164,7 +164,11 @@ export default class MediaPlayerObject {
   }
 
   get progress() {
-    return this.position + this.isPlaying ? (Date.now() - new Date(this.updatedAt).getTime()) / 1000.0 : 0.0;
+    if (this.isPlaying) {
+      return this.position + (Date.now() - new Date(this.updatedAt).getTime()) / 1000.0;
+    } else {
+      return this.position;
+    }
   }
 
   get idleView() {


### PR DESCRIPTION
Fixes #346 

I'm not sure why nobody made this fix before, maybe I'm missing something?

Tested with [yandex_station](https://github.com/AlexxIT/YandexStation) (custom component) and [cast](https://github.com/home-assistant/core/blob/dev/homeassistant/components/cast/media_player.py) (official from hass/core). Entities from these integrations have their `media_position_updated_at` attribute frozen after pausing, don't know about others. 

Freezing this attribute makes player position increase indefinitely. Checking if the player actually playing eliminates the problem.