### PR TITLE
Added support for the new default grouping functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ See [Speaker group management](#speaker-group-management) for example usage.
 - snapcast<sup>[2](#speaker_foot2)</sup>
 - musiccast_yamaha<sup>[1](#speaker_foot1)</sup>
 - linkplay<sup>[3](#speaker_foot3)</sup>
+- media_player<sup>[4](#speaker_foot4)</sup>
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
@@ -146,12 +147,15 @@ See [Speaker group management](#speaker-group-management) for example usage.
 | show_group_count | boolean | true | Have the number of grouped speakers displayed (if any) in the card name.
 | icon | string | optional | Override default group button icon *(any mdi icon)*.
 | group_mgmt_entity | string | optional | Override the player entity for the group management (Useful if you use a universal media_player as your entity but still want to use the grouping feature)
+| support_master | boolean | optional | Set to false if your multiroom system does not define one of the media players as master. Defaults to `true` and has not to be set to false for `squeezebox` for backward compatibility.
 
 <a name="speaker_foot1"><sup>1</sup></a> Requires [custom component](https://github.com/ppanagiotis/pymusiccast), available in HACS.
 
 <a name="speaker_foot2"><sup>2</sup></a> All features are not yet supported.
 
 <a name="speaker_foot3"><sup>3</sup></a> Requires [custom component](https://github.com/nagyrobi/home-assistant-custom-components-linkplay#multiroom) for sound devices based on Linkplay chipset, available in HACS.
+
+<a name="speaker_foot4"><sup>4</sup></a> HomeAssistant added join/unjoin services to the media_player. Future official integrations will implement these services (which are slightly different from the ones, which are already supported by this card) instead of implementing them in their own domain.
 
 #### Speaker entity object
 | Name | Type | Default | Description |

--- a/src/const.js
+++ b/src/const.js
@@ -63,6 +63,7 @@ const PLATFORM = {
   SQUEEZEBOX: 'squeezebox',
   BLUESOUND: 'bluesound',
   SOUNDTOUCH: 'soundtouch',
+  MEDIAPLAYER: 'media_player',
 };
 
 const CONTRAST_RATIO = 4.5;

--- a/src/model.js
+++ b/src/model.js
@@ -87,6 +87,9 @@ export default class MediaPlayerObject {
     if (this.platform === PLATFORM.SQUEEZEBOX) {
       return this.attr.sync_group || [];
     }
+    if (this.platform === PLATFORM.MEDIAPLAYER) {
+      return this.attr.group_members || [];
+    }
     return this.attr[`${this.platform}_group`] || [];
   }
 
@@ -352,6 +355,11 @@ export default class MediaPlayerObject {
             entity_id: this.entityId,
             other_player: entity,
           }, PLATFORM.SQUEEZEBOX);
+        case PLATFORM.MEDIAPLAYER:
+          return this.callService(e, 'join', {
+            entity_id: this.entityId,
+            group_members: entity,
+          }, platform);
         default:
           return this.callService(e, 'join', options, platform);
       }
@@ -361,6 +369,10 @@ export default class MediaPlayerObject {
           return this.handleSoundtouch(e, 'REMOVE_ZONE_SLAVE', entity);
         case PLATFORM.SQUEEZEBOX:
           return this.callService(e, 'unsync', options, PLATFORM.SQUEEZEBOX);
+        case PLATFORM.MEDIAPLAYER:
+          return this.callService(e, 'unjoin', {
+            entity_id: entity,
+          }, platform);
         default:
           return this.callService(e, 'unjoin', options, platform);
       }

--- a/src/model.js
+++ b/src/model.js
@@ -214,7 +214,7 @@ export default class MediaPlayerObject {
   }
 
   get supportsMaster() {
-    return this.platform !== PLATFORM.SQUEEZEBOX;
+    return this.platform !== PLATFORM.SQUEEZEBOX && this.config.speaker_group.supports_master;
   }
 
   async fetchArtwork() {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -29,6 +29,7 @@ export const generateConfig = (config) => {
     speaker_group: {
       show_group_count: true,
       platform: 'sonos',
+      supports_master: true,
       ...config.sonos,
       ...config.speaker_group,
     },


### PR DESCRIPTION
HA has defined a new service schema for join and unjoin in the media_player component. Future (official) integrations will use these services instead of implementing join/unjoin in their domain.
To enable using these base services, the platform has to be set to media_player in the cards config, so that it offers full backward compatibility.

This was already requested in #519 and will also be needed in the future for other integrations (such as the rewritten official musiccast integration).