### PR TITLE
Add remaining runtime display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | mute | boolean | false | The mute button.
 | progress | boolean | false | The progress bar.
 | runtime | boolean | true | The media runtime indicators.
+| runtime_remaining | boolean | true | The media remaining runtime (requires `runtime` option to be visible).
 | artwork_border | boolean | true | The border of the `default` artwork picture.
 | power_state | boolean | true | Dynamic color of the power button to indicate on/off.
 | icon_state | boolean | true | Dynamic color of the entity icon to indicate entity state.

--- a/src/components/progress.js
+++ b/src/components/progress.js
@@ -8,6 +8,7 @@ class MiniMediaPlayerProgress extends LitElement {
     return {
       _player: {},
       showTime: Boolean,
+      showRemainingTime: Boolean,
       progress: Number,
       duration: Number,
       tracker: {},
@@ -63,8 +64,15 @@ class MiniMediaPlayerProgress extends LitElement {
         ?paused=${!this.player.isPlaying}>
         ${this.showTime ? html`
           <div class='mmp-progress__duration'>
-            <span>${(convertProgress(this.seekProgress || this.progress))}</span>
-            <span>${(convertProgress(this.duration))}</span>
+            <span>${convertProgress(this.seekProgress || this.progress)}</span>
+            <div>
+              ${this.showTime ? html`
+                <span class='mmp-progress__duration__remaining'>
+                  -${(convertProgress(this.duration - (this.seekProgress || this.progress)))} |
+                </span>
+              ` : ''}
+              <span>${convertProgress(this.duration)}</span>
+            </div>
           </div>
         ` : ''}
         <paper-progress class=${this.classes}
@@ -150,6 +158,9 @@ class MiniMediaPlayerProgress extends LitElement {
         font-size: .8em;
         padding: 0 6px;
         z-index: 2
+      }
+      .mmp-progress__duration__remaining {
+        opacity: .5;
       }
       paper-progress {
         height: var(--mmp-progress-height);

--- a/src/const.js
+++ b/src/const.js
@@ -5,6 +5,7 @@ const DEFAULT_HIDE = {
   icon_state: true,
   sound_mode: true,
   runtime: true,
+  runtime_remaining: true,
   volume: false,
   volume_level: true,
   controls: false,

--- a/src/main.js
+++ b/src/main.js
@@ -225,7 +225,8 @@ class MiniMediaPlayer extends LitElement {
           ${this.player.active && this.player.hasProgress ? html`
             <mmp-progress
               .player=${this.player}
-              .showTime=${!this.config.hide.runtime}>
+              .showTime=${!this.config.hide.runtime}
+              .showRemainingTime=${!this.config.hide.runtime_remaining}>
             </mmp-progress>
           ` : ''}
         </div>

--- a/src/utils/getProgress.js
+++ b/src/utils/getProgress.js
@@ -1,7 +1,7 @@
 export default (duration) => {
-  let seconds = parseInt(duration % 60, 10);
-  let minutes = parseInt((duration / 60) % 60, 10);
-  let hours = parseInt((duration / (60 * 60)) % 24, 10);
+  let seconds = Math.abs(parseInt(duration % 60, 10));
+  let minutes = Math.abs(parseInt((duration / 60) % 60, 10));
+  let hours = Math.abs(parseInt((duration / (60 * 60)) % 24, 10));
 
   hours = (hours < 10) ? `0${hours}` : hours;
   minutes = (minutes < 10) ? `0${minutes}` : minutes;


### PR DESCRIPTION
Adds new display option `runtime_remaining`, to display remaining runtime of playing media.

<img width="705" alt="Screenshot 2021-10-01 at 11 10 34" src="https://user-images.githubusercontent.com/457678/135595454-2f343a55-bded-451a-897b-4985753a8dfe.png">



Fixes #501