### PR TITLE
Jump feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Inspired by [Custom UI: Mini media player](https://community.home-assistant.io/t
 | max_volume | number | optional | v0.8.2 | Specify the max vol limit of the volume slider (number between 1 - 100).
 | min_volume | number | optional | v1.1.2 | Specify the min vol limit of the volume slider (number between 1 - 100).
 | replace_mute | string | optional | v0.9.8 | Replace the mute button, available options are `play_pause` (previously `play`), `stop`, `play_stop`, `next`.
+| jump_amount | number | 10 | v0.14.0 | Configure amount of seconds to skip/rewind for jump buttons.
 | toggle_power | boolean | true | v0.8.9 | Set to `false` to change the power button behaviour to `media_player.turn_on`/`media_player.turn_off`.
 | idle_view | object | optional | v1.0.0 | Display a less cluttered view when idle, See [Idle object](#idle-object) for available options.
 | background | string | optional | v0.8.6 | Background image, specify the image url `"/local/background-img.png"` e.g.
@@ -221,6 +222,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | next | boolean | false | The "next" playback control button.
 | play_pause | boolean | false | The play/pause button in media playback controls.
 | play_stop | boolean | true | The play/stop button in media playback controls.
+| jump | boolean | true | The jump backwards/forwards buttons (entity needs to support progress).
 | volume | boolean | false | The volume controls.
 | volume_level | boolean | true | The current volume level in percentage.
 | mute | boolean | false | The mute button.

--- a/src/components/mediaControls.js
+++ b/src/components/mediaControls.js
@@ -29,6 +29,10 @@ class MiniMediaPlayerMediaControls extends LitElement {
     return Math.round(this.player.vol * 100);
   }
 
+  get jumpAmount() {
+    return this.config.jump_amount || 10;
+  }
+
   render() {
     const { hide } = this.config;
     return html`
@@ -50,7 +54,9 @@ class MiniMediaPlayerMediaControls extends LitElement {
               @click=${e => this.player.prev(e)}
               .icon=${ICON.PREV}>
             </ha-icon-button>` : ''}
+          ${this.renderJumpBackwardButton()}
           ${this.renderPlayButtons()}
+          ${this.renderJumpForwardButton()}
           ${!hide.next && this.player.supportsNext ? html`
             <ha-icon-button
               @click=${e => this.player.next(e)}
@@ -174,6 +180,28 @@ class MiniMediaPlayerMediaControls extends LitElement {
           .icon=${hide.play_pause ? ICON.STOP[this.player.isPlaying] : ICON.STOP.true}>
         </ha-icon-button>
       ` : html``}
+    `;
+  }
+
+  renderJumpForwardButton() {
+    const hidden = this.config.hide.jump;
+    if (hidden || !this.player.hasProgress) return html``;
+    return html`
+      <ha-icon-button
+        @click=${e => this.player.jump(e, this.jumpAmount)}
+        .icon=${ICON.FAST_FORWARD}>
+      </ha-icon-button>
+    `;
+  }
+
+  renderJumpBackwardButton() {
+    const hidden = this.config.hide.jump;
+    if (hidden || !this.player.hasProgress) return html``;
+    return html`
+      <ha-icon-button
+        @click=${e => this.player.jump(e, -this.jumpAmount)}
+        .icon=${ICON.REWIND}>
+      </ha-icon-button>
     `;
   }
 

--- a/src/const.js
+++ b/src/const.js
@@ -12,6 +12,7 @@ const DEFAULT_HIDE = {
   play_stop: true,
   prev: false,
   next: false,
+  jump: true,
   state_label: false,
 };
 const ICON = {
@@ -38,6 +39,8 @@ const ICON = {
   },
   VOL_DOWN: 'mdi:volume-minus',
   VOL_UP: 'mdi:volume-plus',
+  FAST_FORWARD: 'mdi:fast-forward',
+  REWIND: 'mdi:rewind',
 };
 
 const UPDATE_PROPS = ['entity', 'groupMgmtEntity', '_overflow',

--- a/src/model.js
+++ b/src/model.js
@@ -322,6 +322,14 @@ export default class MediaPlayerObject {
     this.callService(e, 'media_seek', { seek_position: pos });
   }
 
+  jump(e, amount) {
+    const newPosition = this.progress + amount;
+    const clampedNewPosition = Math.min(
+      Math.max(newPosition, 0), this.mediaDuration || newPosition,
+    );
+    this.callService(e, 'media_seek', { seek_position: clampedNewPosition });
+  }
+
   setVolume(e, vol) {
     if (this.config.speaker_group.sync_volume) {
       this.group.forEach((entity) => {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -37,6 +37,7 @@ export const generateConfig = (config) => {
       label: LABEL_SHORTCUT,
       ...config.shortcuts,
     },
+    jump_amount: 10,
   };
   conf.max_volume = Number(conf.max_volume) || 100;
   conf.min_volume = Number(conf.min_volume) || 0;


### PR DESCRIPTION
Added as an optional feature, disabled by default, see `jump` option in the `hide` option object.
Jump amount in seconds can be configured through the `jump_amount` feature, defaults to `10`.

Requires the entity to expose progress attributes, needed in order to calculate position to seek to.

This feature may be wonky on some media players depending on how well they update the progress, in particular in close conjunction with `media_seek` service calls.

Fixes #457