### PR TITLE
Fix translation for ISO 639-1

### DIFF
--- a/src/utils/translation.js
+++ b/src/utils/translation.js
@@ -6,8 +6,10 @@ const getNestedProp = (obj, path) => path.split('.').reduce((p, c) => p && p[c] 
 
 const translation = (hass, label, hassLabel = undefined, fallback = 'unknown') => {
   const lang = hass.selectedLanguage || hass.language;
+  const l639 = lang.split('-')[0]
   return translations[lang] && getNestedProp(translations[lang], label)
     || hass.resources[lang] && hass.resources[lang][hassLabel]
+    || translations[l639] && getNestedProp(translations[l639], label)
     || getNestedProp(translations[DEFAULT_LANG], label)
     || fallback;
 };

--- a/src/utils/translation.js
+++ b/src/utils/translation.js
@@ -6,7 +6,7 @@ const getNestedProp = (obj, path) => path.split('.').reduce((p, c) => p && p[c] 
 
 const translation = (hass, label, hassLabel = undefined, fallback = 'unknown') => {
   const lang = hass.selectedLanguage || hass.language;
-  const l639 = lang.split('-')[0]
+  const l639 = lang.split('-')[0];
   return translations[lang] && getNestedProp(translations[lang], label)
     || hass.resources[lang] && hass.resources[lang][hassLabel]
     || translations[l639] && getNestedProp(translations[l639], label)


### PR DESCRIPTION
https://github.com/kalkih/mini-media-player/blob/e5ac7b5dcb2e713fab51128f962462af8cec04f6/src/translations.js#L1

But the language code returned by `hass.selectedLanguage || hass.language` with subtag in some regions, such as `zh-Hans` in China.