### PR TITLE
Deleted Line 303

### DIFF
--- a/src/components/mediaControls.js
+++ b/src/components/mediaControls.js
@@ -300,7 +300,6 @@ class MiniMediaPlayerMediaControls extends LitElement {
           flex: 3;
           flex-shrink: 200;
           justify-content: center;
-          --mdc-icon-size: 20px;
         }
       `,
     ];


### PR DESCRIPTION
Line 303 is preventing shuffle button icon from scaling with "scale" option.  Removing it allows resizing of shuffle button icon.

Testing was performed with the spotify integration enabled and the shuffle button shown.