### PR TITLE
fix: Vertical align on dropdown

### DIFF
--- a/src/sharedStyle.js
+++ b/src/sharedStyle.js
@@ -26,7 +26,7 @@ const sharedStyle = css`
   ha-icon-button[inactive] {
     opacity: .5;
   }
-  ha-icon-button ha-icon {
+  ha-icon-button ha-icon, mmp-icon-button ha-icon {
     display: flex;
   }
 `;


### PR DESCRIPTION
The move mwc-menu broke a CSS style.

## Before
<img width="499" alt="Screen Shot 2022-03-03 at 11 11 24 AM" src="https://user-images.githubusercontent.com/1143112/156604740-6328a3d7-2492-4494-9b0b-615bfd418be2.png">

## After
<img width="504" alt="Screen Shot 2022-03-03 at 11 11 33 AM" src="https://user-images.githubusercontent.com/1143112/156604771-b3f4b3ad-71d4-4b88-a372-8838af651263.png">
