### PR TITLE
Fix dumps with `idle_view`

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -84,7 +84,7 @@ export default class MediaPlayerObject {
   }
 
   get updatedAt(): string | number | Date {
-    return this._attr.media_position_updated_at || 0;
+    return this._attr?.media_position_updated_at || 0;
   }
 
   get position(): number {
@@ -248,11 +248,6 @@ export default class MediaPlayerObject {
     } catch (error) {
       return false;
     }
-  }
-
-  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
-  getAttribute(attribute: keyof MediaPlayerEntityAttributes): any {
-    return this._attr[attribute];
   }
 
   toggle(e: MouseEvent): void {


### PR DESCRIPTION
Fixes https://github.com/kalkih/mini-media-player/issues/658

The access to `media_position_updated_at` failed and resulted in the card from rendering with the idle feature.

YAML setup (did not test without the `vertical-stack` but that should have no impact here either way).
```yaml
type: vertical-stack
cards:
  - type: custom:mini-media-player
    entity: media_player.sonos_living_front
    idle_view:
      when_paused: true
```