### PR TITLE
Fix `full-cover-fit` setting in the editor

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -15,7 +15,7 @@ const fireEvent = (node, type, detail = {}, options = {}) => {
   return event;
 };
 
-const OptionsArtwork = ['cover', 'full-cover', 'material', 'cover-fit', 'none'];
+const OptionsArtwork = ['cover', 'full-cover', 'material', 'full-cover-fit', 'none'];
 
 const OptionsSource = ['icon', 'full'];
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -15,7 +15,7 @@ const fireEvent = (node, type, detail = {}, options = {}) => {
   return event;
 };
 
-const OptionsArtwork = ['cover', 'full-cover', 'material', 'full-cover-fit', 'none'];
+const OptionsArtwork = ['cover', 'full-cover', 'full-cover-fit', 'material', 'none'];
 
 const OptionsSource = ['icon', 'full'];
 


### PR DESCRIPTION
Should cover-fit in line 18 not be full-cover-fit? e.g., const OptionsArtwork = ['cover', 'full-cover', 'material', 'full-cover-fit', 'none'];