### PR TITLE
Remove border set in HA 2022.11

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -75,6 +75,7 @@ const style = css`
   }
   ha-card.--group {
     box-shadow: none;
+    border: none;
     --mmp-progress-height: var(--mini-media-player-progress-height, 4px);
   }
   ha-card.--more-info {


### PR DESCRIPTION
Fixes #704. In Home Assistant version 2022.11, the material design language has shifted slightly and started utilizing an actual `border` css rule instead of the "border" intrinsically existing via the `box-shadow`. This fix just removes the `border` rule (leaving the existing `box-shadow` removal to be backwards-compatible with older HA versions).