### PR TITLE
Update fallback border-radius to latest HA style

### DIFF
--- a/src/style.ts
+++ b/src/style.ts
@@ -83,7 +83,7 @@ const style = css`
   .mmp__bg,
   .mmp-player,
   .mmp__container {
-    border-radius: var(--ha-card-border-radius, 0);
+    border-radius: var(--ha-card-border-radius, 12px);
   }
   .mmp__container {
     overflow: hidden;

--- a/src/style.ts
+++ b/src/style.ts
@@ -27,6 +27,7 @@ const style = css`
     --mmp-bg-opacity: var(--mini-media-player-background-opacity, 1);
     --mmp-artwork-opacity: var(--mini-media-player-artwork-opacity, 1);
     --mmp-progress-height: var(--mini-media-player-progress-height, 6px);
+    --mmp-border-radius: var(--ha-card-border-radius, 12px);
     --mdc-theme-primary: var(--mmp-text-color);
     --mdc-theme-on-primary: var(--mmp-text-color);
     --paper-checkbox-unchecked-color: var(--mmp-text-color);
@@ -76,6 +77,7 @@ const style = css`
   ha-card.--group {
     box-shadow: none;
     --mmp-progress-height: var(--mini-media-player-progress-height, 4px);
+    --mmp-border-radius: 0px
   }
   ha-card.--more-info {
     cursor: pointer;
@@ -83,7 +85,7 @@ const style = css`
   .mmp__bg,
   .mmp-player,
   .mmp__container {
-    border-radius: var(--ha-card-border-radius, 12px);
+    border-radius: var(--mmp-border-radius);
   }
   .mmp__container {
     overflow: hidden;


### PR DESCRIPTION
The default border-radius of `ha-card` is now 12px, which is causing the player contents to flow outside the card. Since the container needs `overflow: visible` to allow things like the source dropdown to expand beyond the player itself, it seems most appropriate to have the player contents respect the default. Perhaps this is a regression for older HA installs? Not sure what your stance is regarding maintaining backwards compatibility - worst case scenario I think is older installs could use the css variable `ha-card-border-radius` to override for their needs. However, I think going forward we should try to keep up-to-date with what the HA frontend is doing.
![Screenshot 2022-11-03 at 4 23 38 PM](https://user-images.githubusercontent.com/9346314/199854040-132e7b97-5f50-444d-baf8-dbf05e1784e8.png)
![Screenshot 2022-11-03 at 4 28 43 PM](https://user-images.githubusercontent.com/9346314/199854112-281a3b41-89d7-4361-8671-f9762379c151.png)
