### PR TITLE
Add `full-material`, `square` & `square-material` artwork options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ lovelace:
 | tap_action | [action object](#action-object-options) | true | v0.7.0 | Action on click/tap.
 | group | boolean | optional | v0.1 | Removes paddings, background color and box-shadow.
 | hide | object | optional | v1.0.0 | Manage visible UI elements, see [hide object](#hide-object) for available options.
-| artwork | string | default | v0.4 | `cover` to display current artwork in the card background, `full-cover` to display full artwork, `material` for alternate artwork display with dynamic colors, `full-material` to display full artwork with dynamic colors, `none` to hide artwork, `full-cover-fit` for full cover without cropping.
+| artwork | string | default | v0.4 | `cover` to display current artwork in the card background, `full-cover` to display full artwork, `material` for alternate artwork display with dynamic colors, `full-material` to display full artwork with dynamic colors, `none` to hide artwork, `full-cover-fit` for full cover without cropping. `square` will always display a rectangular card, even when nothing is being played. `square-material` does the same, but adds the dynamic colors also found in the other `-material` options.
 | tts | object | optional | v1.0.0 | Show Text-To-Speech input, see [TTS object](#tts-object) for available options.
 | source | string | optional | v0.7 | Change source select appearance, `icon` for just an icon, `full` for the full source name.
 | sound_mode | string | optional | v1.1.2 | Change sound mode select appearance, `icon` for just an icon, `full` for the full sound mode name.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ lovelace:
 | tap_action | [action object](#action-object-options) | true | v0.7.0 | Action on click/tap.
 | group | boolean | optional | v0.1 | Removes paddings, background color and box-shadow.
 | hide | object | optional | v1.0.0 | Manage visible UI elements, see [hide object](#hide-object) for available options.
-| artwork | string | default | v0.4 | `cover` to display current artwork in the card background, `full-cover` to display full artwork, `material` for alternate artwork display with dynamic colors, `none` to hide artwork, `full-cover-fit` for full cover without cropping.
+| artwork | string | default | v0.4 | `cover` to display current artwork in the card background, `full-cover` to display full artwork, `material` for alternate artwork display with dynamic colors, `full-material` to display full artwork with dynamic colors, `none` to hide artwork, `full-cover-fit` for full cover without cropping.
 | tts | object | optional | v1.0.0 | Show Text-To-Speech input, see [TTS object](#tts-object) for available options.
 | source | string | optional | v0.7 | Change source select appearance, `icon` for just an icon, `full` for the full source name.
 | sound_mode | string | optional | v1.1.2 | Change sound mode select appearance, `icon` for just an icon, `full` for the full sound mode name.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -7,7 +7,7 @@ export interface MiniMediaPlayerBaseConfiguration {
   tap_action?: MiniMediaPlayerAction;
   group?: boolean;
   hide?: MiniMediaPlayerHideConfiguration;
-  artwork?: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-cover-fit';
+  artwork?: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-material' | 'full-cover-fit';
   tts?: MiniMediaPlayerTTSConfiguration;
   source?: 'default' | 'icon' | 'full';
   sound_mode?: 'default' | 'icon' | 'full';
@@ -39,7 +39,7 @@ export interface MiniMediaPlayerBaseConfiguration {
 
 export interface MiniMediaPlayerConfiguration extends MiniMediaPlayerBaseConfiguration {
   entity: string;
-  artwork: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-cover-fit';
+  artwork: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-material' | 'full-cover-fit';
   info: 'default' | 'short' | 'scroll';
   group: boolean;
   volume_stateless: boolean;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -7,7 +7,7 @@ export interface MiniMediaPlayerBaseConfiguration {
   tap_action?: MiniMediaPlayerAction;
   group?: boolean;
   hide?: MiniMediaPlayerHideConfiguration;
-  artwork?: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-material' | 'full-cover-fit';
+  artwork?: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-material' | 'full-cover-fit' | 'square' | 'square-material';
   tts?: MiniMediaPlayerTTSConfiguration;
   source?: 'default' | 'icon' | 'full';
   sound_mode?: 'default' | 'icon' | 'full';
@@ -39,7 +39,7 @@ export interface MiniMediaPlayerBaseConfiguration {
 
 export interface MiniMediaPlayerConfiguration extends MiniMediaPlayerBaseConfiguration {
   entity: string;
-  artwork: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-material' | 'full-cover-fit';
+  artwork: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-material' | 'full-cover-fit' | 'square' | 'square-material';
   info: 'default' | 'short' | 'scroll';
   group: boolean;
   volume_stateless: boolean;

--- a/src/editor.js
+++ b/src/editor.js
@@ -15,7 +15,7 @@ const fireEvent = (node, type, detail = {}, options = {}) => {
   return event;
 };
 
-const OptionsArtwork = ['cover', 'full-cover', 'full-cover-fit', 'material', 'none'];
+const OptionsArtwork = ['cover', 'full-cover', 'full-cover-fit', 'material', 'material', 'full-material', 'none'];
 
 const OptionsSource = ['icon', 'full'];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -320,22 +320,34 @@ class MiniMediaPlayer extends LitElement {
     if (this.config.hide.info) return;
     const items = this.player.mediaInfo;
 
-    return html` <div
-      class="entity__info__media"
-      ?short=${this.config.info === 'short' || !this.player.isActive}
-      ?short-scroll=${this.config.info === 'scroll'}
-      ?scroll=${this.overflow}
-      style="animation-duration: ${this.overflow}s;"
-    >
-      ${this.config.info === 'scroll'
-        ? html` <div>
-            <div class="marquee">
-              ${items.map((i) => html`<span class=${`attr__${i.attr}`}>${i.prefix + i.text}</span>`)}
-            </div>
-          </div>`
-        : ''}
-      ${items.map((i) => html`<span class=${`attr__${i.attr}`}>${i.prefix + i.text}</span>`)}
-    </div>`;
+    if (this.config.artwork.includes('square')) {
+      const artist = items.find((m) => m.attr === 'media_artist');
+      const title = items.find((m) => m.attr === 'media_title');
+      return html` <div
+        class="entity__info__media"
+        style="animation-duration: ${this.overflow}s; padding-bottom: 0.25em;"
+      >
+        ${!!artist ? html`<span class=${`attr__${artist.attr}`}>${artist.prefix + artist.text}</span><br />` : ''}
+        ${!!title ? html`<span class=${`attr__${title.attr}`}>${title.prefix + title.text}</span>` : ''}
+      </div>`;
+    } else {
+      return html` <div
+        class="entity__info__media"
+        ?short=${this.config.info === 'short' || !this.player.isActive}
+        ?short-scroll=${this.config.info === 'scroll'}
+        ?scroll=${this.overflow}
+        style="animation-duration: ${this.overflow}s;"
+      >
+        ${this.config.info === 'scroll'
+          ? html` <div>
+              <div class="marquee">
+                ${items.map((i) => html`<span class=${`attr__${i.attr}`}>${i.prefix + i.text}</span>`)}
+              </div>
+            </div>`
+          : ''}
+        ${items.map((i) => html`<span class=${`attr__${i.attr}`}>${i.prefix + i.text}</span>`)}
+      </div>`;
+    }
   }
 
   speakerCount(): string | undefined {

--- a/src/main.ts
+++ b/src/main.ts
@@ -293,7 +293,7 @@ class MiniMediaPlayer extends LitElement {
       </div>`;
     }
 
-    if (this.config.icon_image != undefined){
+    if (this.config.icon_image != undefined) {
       return html` <div class="entity__icon">
         <img src="${this.config.icon_image}" height="100%" />
       </div>`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ class MiniMediaPlayer extends LitElement {
         this.prevThumbnail = '';
       }, 1000);
     }
-    if (changedProps.has('player') && this.config.artwork === 'material') {
+    if (changedProps.has('player') && this.config.artwork.includes('material')) {
       this.setColors();
     }
     return UPDATE_PROPS.some((prop) => changedProps.has(prop)) && Boolean(this.player);
@@ -357,6 +357,7 @@ class MiniMediaPlayer extends LitElement {
           '--mmp-icon-active-color': this.foregroundColor,
           '--mmp-accent-color': this.foregroundColor,
           '--paper-slider-container-color': this.foregroundColor,
+          '--primary-color': this.backgroundColor,
           '--secondary-text-color': this.foregroundColor,
           '--mmp-media-cover-info-color': this.foregroundColor,
         }),

--- a/src/style.ts
+++ b/src/style.ts
@@ -121,10 +121,14 @@ const style = css`
   header {
     display: none;
   }
+  ha-card[artwork='full-material'].--has-artwork:before {
+    padding-top: 56%;
+  }
   ha-card[artwork='full-cover'].--has-artwork:before {
     padding-top: 56%;
   }
   ha-card[artwork='full-cover'].--has-artwork[content='music']:before,
+  ha-card[artwork='full-material'].--has-artwork[content='music']:before,
   ha-card[artwork='full-cover-fit'].--has-artwork:before {
     padding-top: 100%;
   }
@@ -206,6 +210,9 @@ const style = css`
   }
   ha-card[artwork*='full-cover'].--has-artwork .mmp-player {
     background: linear-gradient(to top, var(--mmp-overlay-color) var(--mmp-overlay-color-stop), transparent 100%);
+  }
+  ha-card[artwork='full-material'].--has-artwork .mmp-player {
+    background: linear-gradient(to top, var(--primary-color), transparent 100%);
   }
   ha-card.--has-artwork .cover,
   ha-card.--has-artwork[artwork='cover'] .cover:before {

--- a/src/style.ts
+++ b/src/style.ts
@@ -85,7 +85,7 @@ const style = css`
     box-shadow: none;
     border: none;
     --mmp-progress-height: var(--mini-media-player-progress-height, 4px);
-    --mmp-border-radius: 0px
+    --mmp-border-radius: 0px;
   }
   ha-card.--more-info {
     cursor: pointer;

--- a/src/style.ts
+++ b/src/style.ts
@@ -218,6 +218,7 @@ const style = css`
   }
   ha-card[artwork='full-material'].--has-artwork .mmp-player,
   ha-card[artwork='square-material'].--has-artwork .mmp-player {
+    padding-top: 175px;
     background: linear-gradient(to top, var(--primary-color), transparent 100%);
   }
   ha-card.--has-artwork .cover,
@@ -396,7 +397,7 @@ const style = css`
   ha-card[artwork='square'] .entity__info__media .attr__media_title,
   ha-card[artwork='square-material'] .entity__info__media .attr__media_title {
     font-size: 1.75em;
-    line-height: 1.1
+    line-height: 1.1;
   }
   ha-card[artwork='square'] .entity__info__media .attr__media_artist,
   ha-card[artwork='square-material'] .entity__info__media .attr__media_artist {
@@ -404,7 +405,7 @@ const style = css`
   }
   ha-card[artwork='square'] .entity__info__media .attr__media_title,
   ha-card[artwork='square-material'] .entity__info__media .attr__media_title {
-    font-weight: 500
+    font-weight: 500;
   }
   .mmp-player__adds {
     margin-left: calc(var(--mmp-unit) * 1.2);

--- a/src/style.ts
+++ b/src/style.ts
@@ -38,6 +38,7 @@ const style = css`
     --mmp-info-opacity: 0.75;
   }
   ha-card.--has-artwork[artwork='material'],
+  ha-card.--has-artwork[artwork='square'],
   ha-card.--has-artwork[artwork*='cover'] {
     --mmp-accent-color: var(
       --mini-media-player-overlay-accent-color,
@@ -120,6 +121,10 @@ const style = css`
   }
   header {
     display: none;
+  }
+  ha-card[artwork='square']:before,
+  ha-card[artwork='square-material']:before {
+    padding-top: 100%;
   }
   ha-card[artwork='full-material'].--has-artwork:before {
     padding-top: 56%;
@@ -211,7 +216,8 @@ const style = css`
   ha-card[artwork*='full-cover'].--has-artwork .mmp-player {
     background: linear-gradient(to top, var(--mmp-overlay-color) var(--mmp-overlay-color-stop), transparent 100%);
   }
-  ha-card[artwork='full-material'].--has-artwork .mmp-player {
+  ha-card[artwork='full-material'].--has-artwork .mmp-player,
+  ha-card[artwork='square-material'].--has-artwork .mmp-player {
     background: linear-gradient(to top, var(--primary-color), transparent 100%);
   }
   ha-card.--has-artwork .cover,
@@ -368,6 +374,7 @@ const style = css`
     white-space: nowrap;
   }
   ha-card[artwork*='cover'].--has-artwork .entity__info__media,
+  ha-card[artwork='square'].--has-artwork .entity__info__media,
   ha-card.--bg .entity__info__media {
     color: var(--mmp-media-cover-info-color);
   }
@@ -379,6 +386,25 @@ const style = css`
   }
   .entity__info__media span:empty {
     display: none;
+  }
+  ha-card[artwork='square'] .entity__info__media span:before,
+  ha-card[artwork='square-material'] .entity__info__media span:before {
+    content: '';
+  }
+  ha-card[artwork='square'] .entity__info__media .attr__media_artist,
+  ha-card[artwork='square-material'] .entity__info__media .attr__media_artist,
+  ha-card[artwork='square'] .entity__info__media .attr__media_title,
+  ha-card[artwork='square-material'] .entity__info__media .attr__media_title {
+    font-size: 1.75em;
+    line-height: 1.1
+  }
+  ha-card[artwork='square'] .entity__info__media .attr__media_artist,
+  ha-card[artwork='square-material'] .entity__info__media .attr__media_artist {
+    font-weight: 300;
+  }
+  ha-card[artwork='square'] .entity__info__media .attr__media_title,
+  ha-card[artwork='square-material'] .entity__info__media .attr__media_title {
+    font-weight: 500
   }
   .mmp-player__adds {
     margin-left: calc(var(--mmp-unit) * 1.2);


### PR DESCRIPTION
This PR will add the following artwork styles:

- `full-material`:  display full cover, with material dynamic colors
- `square`: variant of `full-cover` that always remains full height (i.e. square), even when nothing is being played
- `square-material`: variant of `square` with dynamic colors