### PR TITLE
Fix TTS field after HA 2023.11.0 update

### DIFF
--- a/src/components/tts.js
+++ b/src/components/tts.js
@@ -30,14 +30,13 @@ class MiniMediaPlayerTts extends LitElement {
 
   render() {
     return html`
-      <paper-input
+      <ha-textfield
         id="tts-input"
         class="mmp-tts__input"
-        no-label-float
         placeholder="${this.label}..."
         @click=${e => e.stopPropagation()}
       >
-      </paper-input>
+      </ha-textfield>
       <mmp-button class="mmp-tts__button" @click=${this.handleTts}>
         <span>${t(this.hass, 'label.send')}</span>
       </mmp-button>
@@ -108,16 +107,13 @@ class MiniMediaPlayerTts extends LitElement {
     return css`
       :host {
         align-items: center;
-        margin-left: 8px;
+        margin: 8px 4px 0px;
         display: flex;
       }
       .mmp-tts__input {
         cursor: text;
         flex: 1;
         margin-right: 8px;
-        --paper-input-container-input: {
-          font-size: 1em;
-        };
       }
       ha-card[rtl] .mmp-tts__input {
         margin-right: auto;
@@ -127,24 +123,6 @@ class MiniMediaPlayerTts extends LitElement {
         margin: 0;
         height: 30px;
         padding: 0 .4em;
-      }
-      paper-input {
-        opacity: .75;
-        --paper-input-container-color: var(--mmp-text-color);
-        --paper-input-container-input-color: var(--mmp-text-color);
-        --paper-input-container-focus-color: var(--mmp-text-color);
-        --paper-input-container: {
-          padding: 0;
-        };
-      }
-      paper-input[focused] {
-        opacity: 1;
-      }
-
-      ha-card[artwork*='cover'][has-artwork] paper-input {
-        --paper-input-container-color: #FFFFFF;
-        --paper-input-container-input-color: #FFFFFF;
-        --paper-input-container-focus-color: #FFFFFF;
       }
     `;
   }

--- a/src/style.ts
+++ b/src/style.ts
@@ -60,6 +60,13 @@ const style = css`
     --switch-unchecked-color: var(--mmp-text-color);
     --switch-unchecked-button-color: var(--mmp-text-color);
     --switch-unchecked-track-color: var(--mmp-text-color);
+    --mdc-text-field-fill-color: transparent;
+    --mdc-text-field-ink-color: var(--mmp-text-color);
+    --mdc-text-field-idle-line-color: var(--mmp-text-color);
+    --mdc-text-field-label-ink-color: var(--mmp-text-color);
+    --mdc-text-field-hover-line-color: var(--mmp-text-color);
+    --mdc-ripple-color: var(--mmp-text-color);
+    --text-field-padding: 0;
     color: var(--mmp-text-color);
   }
   ha-card {


### PR DESCRIPTION
I decided to leave the standard HA style for the default state, with gray background.
Fixes #785

![chrome_2023-12-04_02-07-42](https://github.com/kalkih/mini-media-player/assets/11841379/a7033ead-5f09-4cde-a2f7-11a4f6583f79)
![chrome_2023-12-04_02-15-00](https://github.com/kalkih/mini-media-player/assets/11841379/d18a8730-1cb4-4c90-914b-5f99b1794716)
![chrome_2023-12-04_02-08-15](https://github.com/kalkih/mini-media-player/assets/11841379/a95f57e1-3636-4d65-aa76-b237e0dbce50)
![chrome_2023-12-04_02-14-03](https://github.com/kalkih/mini-media-player/assets/11841379/2a17c410-9dcc-4d4c-bd77-45d44061e2bd)