### PR TITLE
Add support `assumed_state` media players

### DIFF
--- a/src/components/mediaControls.js
+++ b/src/components/mediaControls.js
@@ -204,7 +204,18 @@ class MiniMediaPlayerMediaControls extends LitElement {
   renderPlayButtons() {
     const { hide } = this.config;
     return html`
-      ${!hide.play_pause ? html`
+      ${!hide.play_pause ? this.player.assumedState ? html`
+        <ha-icon-button
+          @click=${e => this.player.play(e)}
+          .icon=${ICON.PLAY.false}>
+            <ha-icon .icon=${ICON.PLAY.false}></ha-icon>
+        </ha-icon-button>
+        <ha-icon-button
+          @click=${e => this.player.pause(e)}
+          .icon=${ICON.PLAY.true}>
+            <ha-icon .icon=${ICON.PLAY.true}></ha-icon>
+        </ha-icon-button>
+      ` : html`
         <ha-icon-button
           @click=${e => this.player.playPause(e)}
           .icon=${ICON.PLAY[this.player.isPlaying]}>

--- a/src/model.ts
+++ b/src/model.ts
@@ -67,6 +67,10 @@ export default class MediaPlayerObject {
     return (!this.isOff && !this.isUnavailable && !this.idle) || false;
   }
 
+  get assumedState(): boolean {
+    return this._attr.assumed_state || false;
+  }
+
   get shuffle(): boolean {
     return this._attr.shuffle || false;
   }
@@ -293,6 +297,14 @@ export default class MediaPlayerObject {
   // TODO: fix opts type
   setMedia(e: MouseEvent, opts: MediaPlayerMedia): void {
     this.callService(e, 'play_media', { ...opts });
+  }
+
+  play(e: MouseEvent): void {
+    this.callService(e, 'media_play');
+  }
+
+  pause(e: MouseEvent): void {
+    this.callService(e, 'media_pause');
   }
 
   playPause(e: MouseEvent): void {


### PR DESCRIPTION
Reopening an accidentally closed #719 due to the re-creation of a fork.

This small PR will add support of `assumed_state` media_players. Such players have separate play/pause controls and typically do not support control over `media_play_pause` service call.

Native media player card looks like this, if media player has `assumed_state: true` (https://github.com/home-assistant/frontend/pull/11642):

<img width="350" alt="image" src="https://user-images.githubusercontent.com/11841379/210122695-8be53a9d-59e8-4fb1-bc5d-0c4c76516995.png">

This change contains the same logic:

<img width="350" alt="image" src="https://user-images.githubusercontent.com/11841379/210122779-4d73ae1f-bdb1-4259-9aea-4c73900b80db.png">

I'm also attach a list of core integrations where it is used at this moment:

- [Android TV Remote](https://github.com/home-assistant/core/blob/ef887e529fd33c7fbf32e19b133072cb8ca466d6/homeassistant/components/androidtv_remote/media_player.py#L40)
- [LG WebOS TV](https://github.com/home-assistant/core/blob/cc4e741cfa21973cae47a0726e83ec2e51f8ba97/homeassistant/components/webostv/media_player.py#L123)
- [LG Netcast TV](https://github.com/home-assistant/core/blob/a338e7e2426f70467462cce2be60e86b9d1cec43/homeassistant/components/lg_netcast/media_player.py#L78)
- [Phillips TV](https://github.com/home-assistant/core/blob/ef887e529fd33c7fbf32e19b133072cb8ca466d6/homeassistant/components/philips_js/media_player.py#L487)
- [Sony Bravia TV](https://github.com/home-assistant/core/blob/ef887e529fd33c7fbf32e19b133072cb8ca466d6/homeassistant/components/braviatv/media_player.py#L43)
- [Xiaomi TV](https://github.com/home-assistant/core/blob/cc4e741cfa21973cae47a0726e83ec2e51f8ba97/homeassistant/components/xiaomi_tv/media_player.py#L61)