### PR TITLE
Add hide group-button option

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | power | boolean | false | The power button.
 | source | boolean | false | The source select.
 | sound_mode | boolean | true | The sound_mode select.
+| group_button | boolean | false | The group button.
 | controls | boolean | false | The media playback controls.
 | prev | boolean | false | The "previous" playback control button.
 | next | boolean | false | The "next" playback control button.

--- a/src/components/powerstrip.js
+++ b/src/components/powerstrip.js
@@ -25,7 +25,7 @@ class MiniMediaPlayerPowerstrip extends LitElement {
   }
 
   get showGroupButton() {
-    return this.config.speaker_group.entities.length > 0;
+    return this.config.speaker_group.entities.length > 0 && !this.config.hide.group_button;
   }
 
   get showPowerButton() {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -150,6 +150,7 @@ interface MiniMediaPlayerHideConfiguration {
   artwork_border: boolean;
   icon_state: boolean;
   sound_mode: boolean;
+  group_button: boolean;
   runtime: boolean;
   runtime_remaining: boolean;
   volume: boolean;

--- a/src/const.ts
+++ b/src/const.ts
@@ -5,6 +5,7 @@ const DEFAULT_HIDE = {
   artwork_border: true,
   icon_state: true,
   sound_mode: true,
+  group_button: false,
   runtime: true,
   runtime_remaining: true,
   volume: false,


### PR DESCRIPTION
The new option allows to hide the group-button in the top right:
![image](https://github.com/kalkih/mini-media-player/assets/1368405/a5d02e14-94a9-459b-9cfe-c0b28a43f9f7)

I can hide all the other elements in the topbar, but not the group button. Since I want to show the group all the time I don't need this button. 