### PR TITLE
Pause no longer shows up when it's not supported; now shows both paused and stop by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | prev | boolean | false | The "previous" playback control button.
 | next | boolean | false | The "next" playback control button.
 | play_pause | boolean | false | The play/pause button in media playback controls.
-| play_stop | boolean | true | The play/stop button in media playback controls.
+| play_stop | boolean | false | The play/stop button in media playback controls.
 | jump | boolean | true | The jump backwards/forwards buttons (entity needs to support progress).
 | volume | boolean | false | The volume controls.
 | volume_level | boolean | true | The current volume level in percentage.

--- a/src/components/mediaControls.js
+++ b/src/components/mediaControls.js
@@ -204,7 +204,7 @@ class MiniMediaPlayerMediaControls extends LitElement {
   renderPlayButtons() {
     const { hide } = this.config;
     return html`
-      ${!hide.play_pause ? this.player.assumedState ? html`
+      ${(!hide.play_pause && this.player.supportsPause) ? this.player.assumedState ? html`
         <ha-icon-button
           @click=${e => this.player.play(e)}
           .icon=${ICON.PLAY.false}>
@@ -222,11 +222,11 @@ class MiniMediaPlayerMediaControls extends LitElement {
             <ha-icon .icon=${ICON.PLAY[this.player.isPlaying]}></ha-icon>
         </ha-icon-button>
       ` : html``}
-      ${!hide.play_stop ? html`
+      ${(!hide.play_stop && this.player.supportsStop) ? html`
         <ha-icon-button
           @click=${e => this.handleStop(e)}
           .icon=${hide.play_pause ? ICON.STOP[this.player.isPlaying] : ICON.STOP.true}>
-            <ha-icon .icon=${hide.play_pause ? ICON.STOP[this.player.isPlaying] : ICON.STOP.true}></ha-icon>
+            <ha-icon .icon=${(hide.play_pause || !this.player.supportsPause) ? ICON.STOP[this.player.isPlaying] : ICON.STOP.true}></ha-icon>
         </ha-icon-button>
       ` : html``}
     `;
@@ -257,7 +257,7 @@ class MiniMediaPlayerMediaControls extends LitElement {
   }
 
   handleStop(e) {
-    return this.config.hide.play_pause ? this.player.playStop(e) : this.player.stop(e);
+    return (this.config.hide.play_pause || !this.player.supportsPause) ? this.player.playStop(e) : this.player.stop(e);
   }
 
   handleVolumeChange(ev) {

--- a/src/const.ts
+++ b/src/const.ts
@@ -12,7 +12,7 @@ const DEFAULT_HIDE = {
   volume_level: true,
   controls: false,
   play_pause: false,
-  play_stop: true,
+  play_stop: false,
   prev: false,
   next: false,
   jump: true,

--- a/src/model.ts
+++ b/src/model.ts
@@ -186,6 +186,18 @@ export default class MediaPlayerObject {
     return !!this._attr.supported_features && (this._attr.supported_features | 32) === this._attr.supported_features;
   }
 
+  get supportsPause(): boolean {
+    return !!this._attr.supported_features && (this._attr.supported_features | 1) === this._attr.supported_features;
+  }
+
+  get supportsPlay(): boolean {
+    return !!this._attr.supported_features && (this._attr.supported_features | 16384) === this._attr.supported_features;
+  }
+
+  get supportsStop(): boolean {
+    return !!this._attr.supported_features && (this._attr.supported_features | 4096) === this._attr.supported_features;
+  }
+
   get progress(): number {
     if (this.isPlaying) {
       return this.position + (Date.now() - new Date(this.updatedAt).getTime()) / 1000.0;


### PR DESCRIPTION
Hi,
I was using this while writing an integration for a home audio controller. The controller supports internet radio, which does not support a pause button, leading to errors when the default pause button was clicked. Internet radio does, however, support a stop button. Furthermore, I would like to be able to change the source of the audio from internet radio to something else, such as Spotify,  which does support pause, without needing to modify the mini media player's configuration.

This change makes both play/pause and play/stop enabled by default, as opposed to only play/pause being enabled. Furthermore, this change will hide pause and stop if those commands are not supported by the source device.