### PR TITLE
Only show progress if there is a non-negative `media_duration`

### DIFF
--- a/src/const.ts
+++ b/src/const.ts
@@ -75,7 +75,9 @@ const UPDATE_PROPS = [
   'foregroundColor',
 ];
 
-const PROGRESS_PROPS = ['media_duration', 'media_position', 'media_position_updated_at'];
+const MEDIA_DURATION_PROP = 'media_duration';
+
+const PROGRESS_PROPS = [MEDIA_DURATION_PROP, 'media_position', 'media_position_updated_at'];
 
 const BREAKPOINT = 390;
 
@@ -108,6 +110,7 @@ export {
   DEFAULT_HIDE,
   ICON,
   UPDATE_PROPS,
+  MEDIA_DURATION_PROP,
   PROGRESS_PROPS,
   BREAKPOINT,
   LABEL_SHORTCUT,

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,5 +1,5 @@
 import { MiniMediaPlayerConfiguration } from './config/types';
-import { PROGRESS_PROPS, MEDIA_INFO, PLATFORM, REPEAT_STATE } from './const';
+import { PROGRESS_PROPS, MEDIA_DURATION_PROP, MEDIA_INFO, PLATFORM, REPEAT_STATE } from './const';
 import { HomeAssistant, MediaPlayerEntity, MediaPlayerEntityAttributes, MediaPlayerEntityState } from './types';
 import arrayBufferToBase64 from './utils/misc';
 
@@ -175,7 +175,7 @@ export default class MediaPlayerObject {
   }
 
   get hasProgress(): boolean {
-    return !this.config.hide.progress && !this.idle && PROGRESS_PROPS.every((prop) => prop in this._attr);
+    return !this.config.hide.progress && !this.idle && PROGRESS_PROPS.every((prop) => prop in this._attr) && this._attr[MEDIA_DURATION_PROP] >= 0;
   }
 
   get supportsPrev(): boolean {

--- a/src/model.ts
+++ b/src/model.ts
@@ -175,7 +175,7 @@ export default class MediaPlayerObject {
   }
 
   get hasProgress(): boolean {
-    return !this.config.hide.progress && !this.idle && PROGRESS_PROPS.every((prop) => prop in this._attr) && this._attr[MEDIA_DURATION_PROP] >= 0;
+    return !this.config.hide.progress && !this.idle && PROGRESS_PROPS.every((prop) => prop in this._attr) && (this._attr[MEDIA_DURATION_PROP] ?? -1) > -1;
   }
 
   get supportsPrev(): boolean {


### PR DESCRIPTION
**What**
Only show progress bar if media has a non-negative `media_duration` value

**Why**
Some media streams seem to report a negative `media_duration`, for example

http://lstn.lv/bbc.m3u8?station=bbc_6music&bitrate=320000 results in a `media_duration` of `-1`

Currently the progress bar displays for this stream, but if it gets tapped, an error is shown:


<img width="612" alt="Screenshot 2024-08-17 at 12 40 27" src="https://github.com/user-attachments/assets/d9762a94-988a-4a2d-b575-301e9b1a1e17">

This change fixes that by hiding the progress bar if `media_duration` is below 0.