### PR TITLE
Sort the source list in lexicographic order

### DIFF
--- a/src/components/sourceMenu.ts
+++ b/src/components/sourceMenu.ts
@@ -22,7 +22,7 @@ export class MiniMediaPlayerSourceMenu extends LitElement {
   }
 
   get alternatives(): DropdownItem[] {
-    return this.player.sources.map((source) => ({
+    return this.player.sources.sort().map((source) => ({
       name: source,
       id: source,
       type: 'source',


### PR DESCRIPTION
I am using mpd as my back-end media player.  It currently supplies a list of playlists as sources in a seemingly arbitrary order (map order).  This makes choosing a source from the UI drop down quite cumbersome since they are in no obvious order (e.g. Rock, Pop, Alternative, Jazz, Classical).  This is even more apparent since I have over 20 playlists.

This change implements lexicographic sorting of the source list so that the choices appear in a more logical order. (e.g. Alternative, Classical, Jazz, Pop, Rock).