### PR TITLE
Switch join unjoin services called for linkplay media players

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ See [Speaker group management](#speaker-group-management) for example usage.
 
 <a name="speaker_foot1"><sup>1</sup></a> All features are not yet supported.
 
-<a name="speaker_foot2"><sup>2</sup></a> Requires [custom component](https://github.com/nagyrobi/home-assistant-custom-components-linkplay#multiroom) for sound devices based on Linkplay chipset, available in HACS.
+<a name="speaker_foot2"><sup>2</sup></a> No longer requires [custom component](https://github.com/nagyrobi/home-assistant-custom-components-linkplay#multiroom) since Home Assitant version 2024.08 Linkplay based devices are supported by the Linkplay core integration. The custom integration was supported at least until v1.69.9 of this Custom UI.
 
 <a name="speaker_foot3"><sup>3</sup></a> HomeAssistant added join/unjoin services to the media_player. Future official integrations will implement these services (which are slightly different from the ones, which are already supported by this card) instead of implementing them in their own domain.
 

--- a/src/const.ts
+++ b/src/const.ts
@@ -100,6 +100,7 @@ const PLATFORM = {
   SOUNDTOUCH: 'soundtouch',
   MEDIAPLAYER: 'media_player',
   HEOS: 'heos',
+  LINKPLAY: 'linkplay',
 };
 
 const CONTRAST_RATIO = 4.5;

--- a/src/model.ts
+++ b/src/model.ts
@@ -405,6 +405,7 @@ export default class MediaPlayerObject {
             PLATFORM.SQUEEZEBOX,
           );
         case PLATFORM.MEDIAPLAYER:
+        case PLATFORM.LINKPLAY:
         case PLATFORM.SONOS:
           return this.callService(
             e,
@@ -435,6 +436,7 @@ export default class MediaPlayerObject {
         case PLATFORM.SQUEEZEBOX:
           return this.callService(e, 'unsync', options, PLATFORM.SQUEEZEBOX);
         case PLATFORM.MEDIAPLAYER:
+        case PLATFORM.LINKPLAY:
         case PLATFORM.SONOS:
           return this.callService(
             e,


### PR DESCRIPTION
Update the services join and unjoin called for linkplay based devices. 

The group_members attribute for linkplay devices lists UUIDs instead of entity ids which is currently not handled correctly by mini-media-player. 