### PR TITLE
Stateless volume rounded to 2 decimals

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -336,7 +336,7 @@ export default class MediaPlayerObject {
     if (this.supportsVolumeSet && this.config.volume_step && this.config.volume_step > 0) {
       this.callService(e, 'volume_set', {
         entity_id: this._entityId,
-        volume_level: Math.min(this.vol + this.config.volume_step / 100, 1),
+        volume_level: Math.min(this.vol + this.config.volume_step / 100, 1).toFixed(2),
       });
     } else this.callService(e, 'volume_up');
   }
@@ -345,7 +345,7 @@ export default class MediaPlayerObject {
     if (this.supportsVolumeSet && this.config.volume_step && this.config.volume_step > 0) {
       this.callService(e, 'volume_set', {
         entity_id: this._entityId,
-        volume_level: Math.max(this.vol - this.config.volume_step / 100, 0),
+        volume_level: Math.max(this.vol - this.config.volume_step / 100, 0).toFixed(2),
       });
     } else this.callService(e, 'volume_down');
   }


### PR DESCRIPTION
This is new to me, so not sure if i'm doing this right.

When volume isn't rounded to two decimals and volume_step is 1, certain steps are skipped with the stateless volume buttons.

e.g. 0.03 - 0.01 = 0.199999.....  (volume will be 1%) and because 0.06 + 0.01 = 0.69999999... (volume will be 6%) skipping past 6% isn't possible
