### PR TITLE
Add `adaptive_color` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ lovelace:
 | group | boolean | optional | v0.1 | Removes paddings, background color and box-shadow.
 | hide | object | optional | v1.0.0 | Manage visible UI elements, see [hide object](#hide-object) for available options.
 | artwork | string | default | v0.4 | `cover` to display current artwork in the card background, `full-cover` to display full artwork, `material` for alternate artwork display with dynamic colors, `none` to hide artwork, `full-cover-fit` for full cover without cropping.
+| adaptive_color | boolean | false | v1.17.0 | Extend the WCAG-contrast text color (already used by `material` artwork mode) to `cover`, `full-cover`, and `full-cover-fit`. Useful when the album art is light and the default white text/dropdown becomes unreadable. Off by default for backward compatibility.
 | tts | object | optional | v1.0.0 | Show Text-To-Speech input, see [TTS object](#tts-object) for available options.
 | source | string | optional | v0.7 | Change source select appearance, `icon` for just an icon, `full` for the full source name.
 | sound_mode | string | optional | v1.1.2 | Change sound mode select appearance, `icon` for just an icon, `full` for the full sound mode name.

--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -174,6 +174,7 @@ class MiniMediaPlayerDropdown extends LitElement {
           overflow-y: auto;
           border-radius: 8px;
           background: var(--card-background-color, var(--ha-card-background, #fff));
+          color: var(--primary-text-color);
           box-shadow: var(--ha-card-box-shadow, 0 2px 6px rgba(0, 0, 0, 0.25));
           padding: 4px;
           z-index: 1000;

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -20,6 +20,7 @@ export const generateConfig = (config: MiniMediaPlayerBaseConfiguration): MiniMe
 
   const conf: MiniMediaPlayerConfiguration = {
     artwork: 'default',
+    adaptive_color: false,
     info: 'default',
     group: false,
     volume_stateless: false,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -8,6 +8,7 @@ export interface MiniMediaPlayerBaseConfiguration {
   group?: boolean;
   hide?: MiniMediaPlayerHideConfiguration;
   artwork?: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-cover-fit';
+  adaptive_color?: boolean;
   tts?: MiniMediaPlayerTTSConfiguration;
   source?: 'default' | 'icon' | 'full';
   sound_mode?: 'default' | 'icon' | 'full';
@@ -40,6 +41,7 @@ export interface MiniMediaPlayerBaseConfiguration {
 export interface MiniMediaPlayerConfiguration extends MiniMediaPlayerBaseConfiguration {
   entity: string;
   artwork: 'default' | 'none' | 'cover' | 'full-cover' | 'material' | 'full-cover-fit';
+  adaptive_color: boolean;
   info: 'default' | 'short' | 'scroll';
   group: boolean;
   volume_stateless: boolean;

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ class MiniMediaPlayer extends LitElement {
         this.prevThumbnail = '';
       }, 1000);
     }
-    if (changedProps.has('player') && this.config.artwork === 'material') {
+    if (changedProps.has('player') && this.shouldExtractColors()) {
       this.setColors();
     }
     return UPDATE_PROPS.some((prop) => changedProps.has(prop)) && Boolean(this.player);
@@ -431,6 +431,12 @@ class MiniMediaPlayer extends LitElement {
 
   public getCardSize(): number {
     return this.config.collapse ? 1 : 2;
+  }
+
+  private shouldExtractColors(): boolean {
+    if (this.config.artwork === 'material') return true;
+    if (!this.config.adaptive_color) return false;
+    return ['cover', 'full-cover', 'full-cover-fit'].includes(this.config.artwork);
   }
 
   async setColors(): Promise<void> {


### PR DESCRIPTION
## Problem

In light themes, the `cover`, `full-cover`, and `full-cover-fit` artwork modes can render card text and icons as white-on-white when the album art happens to be light-colored. The source-selector dropdown popover is affected the same way because its items use `color: inherit`, so they pick up the white text color overlay even though the popover itself sits on the theme's card background.

Reported by multiple users:
- #764
- #871
- #759

## Root cause

- `src/style.ts` defines `--mmp-overlay-base-color: #fff` as a hardcoded white.
- The `ha-card.--has-artwork[artwork*='cover']` block in `src/style.ts` unconditionally sets `--mmp-text-color`, icon colors, switch colors, ripple colors, etc. to that white. There is no light-artwork detection in this branch.
- `src/main.ts` already has a full color-extraction pipeline (`setColors()` → `colorsFromPicture()` → node-vibrant + WCAG contrast in `src/utils/colorGenerator.js`), but it only runs when `this.config.artwork === 'material'`. Cover modes never trigger color extraction.
- `computeStyles()` in `main.ts` already injects extracted colors via `--mmp-text-color`, `--mmp-icon-color`, etc. when `foregroundColor` is set, so the hardcoded white in `style.ts` is already designed to act as a safe fallback.
- The dropdown popover (`src/components/dropdown.js`) puts its menu container on top of the theme's `--card-background-color`, but its items use `color: inherit`, which inherits the artwork-overridden text color from the host card and produces white-on-light items.

## Fix

Two surgical changes:

**1. Opt-in color extraction for cover modes (`src/main.ts`, `src/config/types.ts`, `src/config/config.ts`)**

- Add a new opt-in config flag `adaptive_color: boolean` (default `false`).
- Replace the inline `artwork === 'material'` check in `shouldUpdate()` with a small `shouldExtractColors()` helper that returns `true` for `material` (existing behavior) **or** for `cover` / `full-cover` / `full-cover-fit` when `adaptive_color === true`.
- No changes needed to `colorGenerator.js` (WCAG contrast pipeline + YIQ fallback already in place) or to `computeStyles()` (already injects `--mmp-text-color`).

**2. Decouple the dropdown popover from the artwork text color (`src/components/dropdown.js`)**

- Add `color: var(--primary-text-color)` to the `.mmp-dropdown__menu` rule. The popover container now uses the theme text color (which contrasts with its theme card background), so its items remain readable regardless of any artwork overlay color override on the host card.
- The dropdown button inside the card is unaffected — it still inherits the artwork-derived text color and stays readable on the cover.

Total diff: **11 insertions, 1 deletion** across 4 files.

## Behavior for default users

The `adaptive_color` flag defaults to `false`, so for any user who has not explicitly opted in, the color-extraction behavior in main.ts is **byte-identical**. The only behavior change for users who do not opt in is the dropdown popover fix — which strictly improves readability in cover/material modes (and leaves the legacy mwc-menu code path untouched).

## Opting in

```yaml
type: custom:mini-media-player
entity: media_player.living_room
artwork: full-cover
adaptive_color: true
```

## Verification

Tested live against a real Home Assistant instance with `media_player.spotify` cycling through tracks with widely varying album-cover dominant colors:

- Dark covers (e.g. dark blue/teal artwork): extracted foreground is a light cream tone. Card text and dropdown items both readable.
- Light covers (e.g. cream/peach artwork — "Sunset Light" / "Calm Little Boat"): extracted foreground is a dark color. Card text now readable on the light cover (control card with the flag off was white-on-white). Dropdown items always readable thanks to the popover fix.
- Multi-color covers (e.g. teal+yellow "My Sunshine"): extracted foreground picks one of the high-contrast colors via the existing WCAG contrast loop. Dropdown items always readable.

In all cases the control card without `adaptive_color` rendered byte-identically to v1.16.11.

## Notes

- @spacegaier endorsed this direction in the #764 thread — extracting a contrast-appropriate color from the artwork rather than hardcoding white.
- No new dependencies; `node-vibrant` is already in `package.json`.
- `npm run build` passes cleanly.