### PR TITLE
Add media browse button

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ See [card with media shortcuts](#card-with-media-shortcuts) for example usage.
 | source | boolean | false | The source select.
 | sound_mode | boolean | true | The sound_mode select.
 | group_button | boolean | false | The group button.
+| media_browse | boolean | true | The media browse button (only shown when the entity supports `browse_media`).
 | controls | boolean | false | The media playback controls.
 | prev | boolean | false | The "previous" playback control button.
 | next | boolean | false | The "next" playback control button.

--- a/src/components/powerstrip.js
+++ b/src/components/powerstrip.js
@@ -28,6 +28,10 @@ class MiniMediaPlayerPowerstrip extends LitElement {
     return this.config.speaker_group.entities.length > 0 && !this.config.hide.group_button;
   }
 
+  get showBrowseButton() {
+    return !this.config.hide.media_browse && this.player.supportsBrowseMedia;
+  }
+
   get showPowerButton() {
     return !this.config.hide.power;
   }
@@ -83,6 +87,15 @@ class MiniMediaPlayerPowerstrip extends LitElement {
           >
           </mmp-sound-menu>`
         : ''}
+      ${this.showBrowseButton
+        ? html` <ha-icon-button
+            class="browse-button"
+            .icon=${ICON.BROWSE}
+            @click=${(e) => this.handleBrowseClick(e)}
+          >
+            <ha-icon .icon=${ICON.BROWSE}></ha-icon>
+          </ha-icon-button>`
+        : ''}
       ${this.showGroupButton
         ? html` <ha-icon-button
             class="group-button"
@@ -110,6 +123,71 @@ class MiniMediaPlayerPowerstrip extends LitElement {
   handleGroupClick(ev) {
     ev.stopPropagation();
     this.dispatchEvent(new CustomEvent('toggleGroupList'));
+  }
+
+  // Opens the HA media browser dialog (same as the built-in media control card).
+  // HA lazy-loads dialog-media-player-browse via a webpack dynamic import that
+  // custom cards cannot replicate directly. To obtain the real chunk loader, we
+  // instantiate HA's built-in hui-media-control-card, call its _handleBrowseMedia(),
+  // and intercept the show-dialog event to capture the dialogImport function.
+  // On subsequent clicks the dialog element is already registered, so we skip
+  // the loader extraction and fire show-dialog immediately.
+  async handleBrowseClick(ev) {
+    ev.stopPropagation();
+    const entityId = this.player._entityId;
+
+    // Fast path: dialog already loaded
+    if (customElements.get('dialog-media-player-browse')) {
+      this._openBrowseDialog(ev, entityId, () => Promise.resolve());
+      return;
+    }
+
+    // Load the built-in media control card to get access to the webpack
+    // chunk loader for dialog-media-player-browse
+    try {
+      if (!customElements.get('hui-media-control-card')) {
+        const helpers = await window.loadCardHelpers();
+        await helpers.createCardElement({ type: 'media-control', entity: entityId });
+        await customElements.whenDefined('hui-media-control-card');
+      }
+
+      const tempCard = document.createElement('hui-media-control-card');
+      tempCard.setConfig({ type: 'media-control', entity: entityId });
+      tempCard.hass = this.hass;
+
+      let dialogImport = () => Promise.resolve();
+      tempCard.addEventListener('show-dialog', (e) => {
+        e.stopPropagation();
+        dialogImport = e.detail.dialogImport;
+      });
+      tempCard._handleBrowseMedia();
+
+      this._openBrowseDialog(ev, entityId, dialogImport);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('mini-media-player: failed to open browse dialog:', err);
+    }
+  }
+
+  _openBrowseDialog(ev, entityId, dialogImport) {
+    this.dispatchEvent(new CustomEvent('show-dialog', {
+      bubbles: true,
+      composed: true,
+      detail: {
+        dialogTag: 'dialog-media-player-browse',
+        dialogImport,
+        dialogParams: {
+          action: 'play',
+          entityId,
+          mediaPickedCallback: (pickedMedia) => {
+            this.player.setMedia(ev, {
+              media_content_id: pickedMedia.item.media_content_id,
+              media_content_type: pickedMedia.item.media_content_type,
+            });
+          },
+        },
+      },
+    }));
   }
 
   get renderIdleView() {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -151,6 +151,7 @@ interface MiniMediaPlayerHideConfiguration {
   icon_state: boolean;
   sound_mode: boolean;
   group_button: boolean;
+  media_browse: boolean;
   runtime: boolean;
   runtime_remaining: boolean;
   volume: boolean;

--- a/src/const.ts
+++ b/src/const.ts
@@ -6,6 +6,7 @@ const DEFAULT_HIDE = {
   icon_state: true,
   sound_mode: true,
   group_button: false,
+  media_browse: true,
   runtime: true,
   runtime_remaining: true,
   volume: false,
@@ -59,6 +60,7 @@ const ICON = {
   VOL_UP: 'mdi:volume-plus',
   FAST_FORWARD: 'mdi:fast-forward',
   REWIND: 'mdi:rewind',
+  BROWSE: 'mdi:play-box-multiple',
 };
 
 const UPDATE_PROPS = [

--- a/src/model.ts
+++ b/src/model.ts
@@ -186,6 +186,10 @@ export default class MediaPlayerObject {
     return !!this._attr.supported_features && (this._attr.supported_features | 32) === this._attr.supported_features;
   }
 
+  get supportsBrowseMedia(): boolean {
+    return !!this._attr.supported_features && (this._attr.supported_features | 131072) === this._attr.supported_features;
+  }
+
   get progress(): number {
     if (this.isPlaying) {
       return this.position + (Date.now() - new Date(this.updatedAt).getTime()) / 1000.0;


### PR DESCRIPTION
Adds a media browse button for players that support it (hidden per default, to be enabled via config).

Since getting to that dialogue is a bit tricky, this loads a built-in card in the background and uses that for showing the right thing. Uses internal APIs, so things might break on future release but for now it seems to work.

Should take care of #435. #848 and #898.