### PR TITLE
fix(translation): guard hass.resources to prevent crash on render

### DIFF
--- a/src/utils/translation.ts
+++ b/src/utils/translation.ts
@@ -6,12 +6,14 @@ const DEFAULT_LANG = 'en';
 const getNestedProp = (obj, path) => path.split('.').reduce((p, c) => (p && p[c]) || null, obj);
 
 const translation = (hass: HomeAssistant, label: string, hassLabel?: string, fallback = 'unknown'): string => {
-  const lang = hass.selectedLanguage || hass.language;
+  const lang = (hass.selectedLanguage || hass.language || DEFAULT_LANG) as string;
   const l639 = lang.split('-')[0];
+  const resources = hass.resources || {};
   return (
     (translations[lang] && getNestedProp(translations[lang], label)) ||
-    (hass.resources[lang] && hassLabel && hass.resources[lang][hassLabel]) ||
+    (resources[lang] && hassLabel && resources[lang][hassLabel]) ||
     (translations[l639] && getNestedProp(translations[l639], label)) ||
+    (resources[l639] && hassLabel && resources[l639][hassLabel]) ||
     getNestedProp(translations[DEFAULT_LANG], label) ||
     fallback
   );


### PR DESCRIPTION
## Problem

When the card renders in a context where \`hass.resources\` is undefined (early after a reload, or some intermediate hass states), the lookup throws and aborts the whole render:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'en-GB')
    at Te (mini-media-player-bundle.js:557:22144)
    at ze.render (mini-media-player-bundle.js:645:47)
\`\`\`

The crash happens on \`hass.resources[lang]\` in \`src/utils/translation.ts\` when \`hass.resources\` is missing. Reproduced reliably with HA user language set to **British English (\`en-GB\`)** — clicking the speaker-group icon triggers a re-render that crashes, so the dropdown appears empty.

## Fix

The locale-fallback chain itself is already correct (custom translation -> hass resource -> ISO-639 base -> default \`en\` -> fallback string), but \`hass.resources\` was not guarded. Coalesce to \`{}\` so the chain can fall through cleanly.

Two small extras while in here:

- Add a \`hass.resources\` fallback for the ISO-639 base too — so an \`en-GB\` user sees resource strings from \`en\` when no exact match exists.
- Default \`lang\` to \`'en'\` if neither \`hass.selectedLanguage\` nor \`hass.language\` is set, so the subsequent \`lang.split('-')\` is always safe.

## Test plan

- [x] Reload card with HA user language \`en-GB\`; click speaker-group icon; dropdown now populates.
- [x] Reload card with HA user language \`en\`; behavior unchanged.
- [x] No type-checker errors.

No string changes; existing translations untouched.