### PR TITLE
Add card picker sugggestion for media_player entities

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -468,4 +468,14 @@ class MiniMediaPlayer extends LitElement {
   name: 'Mini Media Player',
   preview: false,
   description: 'A minimalistic yet customizable media player card',
+  getEntitySuggestion: (hass: HomeAssistant, entityId: string) => {
+    if (!hass.states[entityId]) return null;
+    if (entityId.split('.')[0] !== 'media_player') return null;
+    return {
+      config: {
+        type: 'custom:mini-media-player',
+        entity: entityId,
+      },
+    };
+  },
 });


### PR DESCRIPTION
Home Assistant `2026.6` lets custom cards suggest themselves in the card picker via getEntitySuggestion. This adds it so Mini Media Player appears under the Community section when a user picks a `media_player` entity.

Suggests the card only for the media_player domain, mirroring the card's own validate() check.
Generates `{ type: 'custom:mini-media-player', entity: entityId }`, which passes the existing config validator as-is.

Docs: https://developers.home-assistant.io/docs/frontend/custom-ui/custom-card#suggesting-your-card-for-an-entity

<img width="1061" height="927" alt="CleanShot 2026-06-03 at 09 51 31" src="https://github.com/user-attachments/assets/d113d694-59aa-4b9c-afe7-ace47e1e4966" />