### PR TITLE
Fix toggle_power false state in editor

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -83,7 +83,7 @@ export default class MiniMediaPlayerEditor extends LitElement {
 
   // eslint-disable-next-line camelcase
   get _toggle_power() {
-    return this._config.toggle_power || true;
+    return this._config.toggle_power ?? true;
   }
 
   render() {


### PR DESCRIPTION
Fixes the visual editor state for `toggle_power: false`.

The editor previously used `|| true` which caused a configured `false` value to be displayed as enabled.