### PR TITLE
Fix fallback dropdown menu opening off-screen

### DIFF
--- a/src/components/dropdown.js
+++ b/src/components/dropdown.js
@@ -41,6 +41,28 @@ class MiniMediaPlayerDropdown extends LitElement {
     menu.anchor = button;
   }
 
+  updated(changedProps) {
+    if (changedProps.has('isOpen') && this.isOpen && !this.hasLegacyMenu) {
+      this.positionFallbackMenu();
+    }
+  }
+
+  positionFallbackMenu() {
+    const menu = this.shadowRoot.querySelector('.mmp-dropdown__menu');
+    if (!menu) return;
+    const margin = 8;
+    menu.style.transform = '';
+    menu.removeAttribute('align-right');
+    let rect = menu.getBoundingClientRect();
+    if (rect.right > document.documentElement.clientWidth - margin) {
+      menu.setAttribute('align-right', '');
+      rect = menu.getBoundingClientRect();
+    }
+    if (rect.left < margin) {
+      menu.style.transform = `translateX(${margin - rect.left}px)`;
+    }
+  }
+
   render() {
     return html`
       <div
@@ -166,10 +188,10 @@ class MiniMediaPlayerDropdown extends LitElement {
         }
         .mmp-dropdown__menu {
           position: absolute;
-          right: 0;
+          left: 0;
           top: calc(100% + 2px);
           min-width: 140px;
-          max-width: 240px;
+          max-width: min(240px, calc(100vw - 16px));
           max-height: 320px;
           overflow-y: auto;
           border-radius: 8px;
@@ -182,6 +204,10 @@ class MiniMediaPlayerDropdown extends LitElement {
         }
         .mmp-dropdown__menu[open] {
           display: block;
+        }
+        .mmp-dropdown__menu[align-right] {
+          left: auto;
+          right: 0;
         }
         .mmp-dropdown__item {
           align-items: center;


### PR DESCRIPTION
**The problem**

The fallback dropdown menu (used since HA no longer ships `mwc-menu`) is absolutely positioned against `.mmp-dropdown`, which shrinks to its label and can be much narrower than the menu itself. With the menu anchored at `right: 0`, it grows leftward from the label's right edge — so whenever the dropdown sits toward the left of a narrow row (e.g. `source: full` on a phone, or a card in a narrow column), the menu runs off the left edge of the viewport and can't be used.

**The fix**

- Anchor the menu to the label's left edge (`left: 0`), which reads as belonging to the control.
- On open, measure and reposition: flip to `right: 0` if the menu would pass the right viewport edge, then translate as a last resort — the menu can no longer leave the screen at any dropdown position or viewport width.
- Cap `max-width` to the viewport for screens narrower than the menu.

Tested on desktop and mobile widths in Chrome and Safari against a Denon receiver entity with `source: full` + `sound_mode: full` (8 sources / 23 sound modes).