### PR TITLE
Decode HTML entities in media info text (title/artist/etc)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import style from './style';
 import sharedStyle from './sharedStyle';
 import handleClick from './utils/handleClick';
 import colorsFromPicture from './utils/colorGenerator';
+import isRtlText from './utils/is-rtl-text';
 
 import './ensureComponents';
 
@@ -319,12 +320,14 @@ class MiniMediaPlayer extends LitElement {
   renderMediaInfo(): TemplateResult | undefined {
     if (this.config.hide.info) return;
     const items = this.player.mediaInfo;
+    const rtl = items.some((i) => isRtlText(i.text));
 
     return html` <div
       class="entity__info__media"
       ?short=${this.config.info === 'short' || !this.player.isActive}
       ?short-scroll=${this.config.info === 'scroll'}
       ?scroll=${this.overflow}
+      ?rtl=${rtl}
       style="animation-duration: ${this.overflow}s;"
     >
       ${this.config.info === 'scroll'

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,6 +2,7 @@ import { MiniMediaPlayerConfiguration } from './config/types';
 import { PROGRESS_PROPS, MEDIA_DURATION_PROP, MEDIA_INFO, PLATFORM, REPEAT_STATE } from './const';
 import { HomeAssistant, MediaPlayerEntity, MediaPlayerEntityAttributes, MediaPlayerEntityState } from './types';
 import arrayBufferToBase64 from './utils/misc';
+import decodeHtmlEntities from './utils/decode-html-entities';
 
 export interface MediaPlayerMedia {
   media_content_type: string;
@@ -168,7 +169,7 @@ export default class MediaPlayerObject {
     attr: string;
   }[] {
     return MEDIA_INFO.map((item) => ({
-      text: this._attr[item.attr],
+      text: decodeHtmlEntities(this._attr[item.attr]),
       prefix: '',
       ...item,
     })).filter((item) => item.text);

--- a/src/style.ts
+++ b/src/style.ts
@@ -351,6 +351,12 @@ const style = css`
   .entity__info__media[scroll] .marquee {
     animation: slide linear infinite;
   }
+  .entity__info__media[scroll][rtl] > div {
+    animation-name: move-rtl;
+  }
+  .entity__info__media[scroll][rtl] .marquee {
+    animation-name: slide-rtl;
+  }
   .entity__info__media[scroll] .marquee,
   .entity__info__media[scroll] > div {
     animation-duration: inherit;
@@ -360,6 +366,10 @@ const style = css`
     animation-duration: 10s;
     mask-image: linear-gradient(to right, transparent 0%, black 5%, black 95%, transparent 100%);
     -webkit-mask-image: linear-gradient(to right, transparent 0%, black 5%, black 95%, transparent 100%);
+  }
+  .entity__info__media[rtl] {
+    direction: rtl;
+    text-align: right;
   }
   .marquee {
     visibility: hidden;
@@ -447,9 +457,22 @@ const style = css`
       transform: translateX(-100%);
     }
   }
+  @keyframes slide-rtl {
+    100% {
+      transform: translateX(100%);
+    }
+  }
   @keyframes move {
     from {
       transform: translateX(100%);
+    }
+    to {
+      transform: translateX(0);
+    }
+  }
+  @keyframes move-rtl {
+    from {
+      transform: translateX(-100%);
     }
     to {
       transform: translateX(0);

--- a/src/utils/decode-html-entities.ts
+++ b/src/utils/decode-html-entities.ts
@@ -1,0 +1,16 @@
+// Some media sources (e.g. certain internet radio stream metadata) send
+// track/title text with HTML entities (`&amp;`, `&#39;`, `&#1605;`, ...)
+// left encoded. Decoding via a detached <textarea> is safe: textarea content
+// is parsed as text/RCDATA, so it can't execute embedded scripts, and it
+// gives us the browser's own (complete, locale-correct) entity decoding
+// instead of reimplementing it.
+const decodeHtmlEntities = (text: string): string => {
+  if (!text) return text;
+  if (!text.includes('&')) return text;
+
+  const el = document.createElement('textarea');
+  el.innerHTML = text;
+  return el.value;
+};
+
+export default decodeHtmlEntities;

--- a/src/utils/decode-html-entities.ts
+++ b/src/utils/decode-html-entities.ts
@@ -1,3 +1,16 @@
+// Some sources (e.g. players relaying a truncated fixed-length metadata
+// buffer) cut text off mid-entity, leaving a dangling, unterminated
+// numeric reference at the very end (`...&#1576;&#1593;&#1`). That
+// fragment can never be decoded — there's no closing `;` — so drop it
+// rather than render it as literal garbage.
+//
+// Deliberately numeric-only (`&#…`/`&#x…`), not named entities: a bare
+// `&#` is never legitimate prose, so this can't misfire, whereas matching
+// short named-entity-shaped suffixes could (e.g. "AT&T" ending in `&T`).
+const TRAILING_INCOMPLETE_ENTITY = /&#x?[0-9a-fA-F]*$/;
+
+const stripTrailingIncompleteEntity = (text: string): string => text.replace(TRAILING_INCOMPLETE_ENTITY, '');
+
 // Some media sources (e.g. certain internet radio stream metadata) send
 // track/title text with HTML entities (`&amp;`, `&#39;`, `&#1605;`, ...)
 // left encoded. Decoding via a detached <textarea> is safe: textarea content
@@ -8,8 +21,9 @@ const decodeHtmlEntities = (text: string): string => {
   if (!text) return text;
   if (!text.includes('&')) return text;
 
+  const trimmed = stripTrailingIncompleteEntity(text);
   const el = document.createElement('textarea');
-  el.innerHTML = text;
+  el.innerHTML = trimmed;
   return el.value;
 };
 

--- a/src/utils/is-rtl-text.ts
+++ b/src/utils/is-rtl-text.ts
@@ -1,0 +1,9 @@
+// Heuristic: treat text as RTL if it contains any strong right-to-left
+// character (Hebrew, Arabic and its supplements/presentation forms, Thaana,
+// N'Ko, and explicit RTL formatting marks). Good enough for choosing a
+// marquee direction without pulling in a full bidi implementation.
+const RTL_REGEX = /[\u0591-\u05F4\u0600-\u06FF\u0750-\u077F\u0780-\u07BF\u07C0-\u07FF\u200F\u202B\u202E\u2067\uFB1D-\uFDFF\uFE70-\uFEFC]/;
+
+const isRtlText = (text: string): boolean => RTL_REGEX.test(text);
+
+export default isRtlText;


### PR DESCRIPTION
### Problem

Some media sources send track metadata with HTML entities left encoded instead of the actual characters. I hit this with a Sonos speaker playing an internet radio station whose ICY stream metadata sends titles like:

```
&#1605;&#1602;&#1583;&#1605;&#1577; &#1593;&#1575;&#1605;&#1577; &#1593;&#1606; &#1581;&#1604;&#1575;&#1608;&#1577;...
```

instead of the actual Arabic text (`مقدمة عامة عن حلاوة...`). `MediaPlayerObject.mediaInfo` (src/model.ts) passes `media_title`/`media_artist`/etc through to the scrolling info marquee verbatim, so the card renders the raw entity codes instead of readable text.

### Fix

Add a small `decodeHtmlEntities` helper (`src/utils/decode-html-entities.ts`) and apply it to each `mediaInfo` item's text. It decodes via a detached `<textarea>` element — this is a well-established safe technique: `textarea` content is parsed as text/RCDATA, not HTML, so embedded markup (e.g. an errant `<script>` in bad stream metadata) can never execute, while still getting full, correct decoding of named/decimal/hex entities for free from the browser's own parser, rather than reimplementing an entity table.

### Testing

- `npm run build` (lint + rollup) passes cleanly.
- Verified locally against my own Sonos entity's `media_title` attribute containing the encoded Arabic example above — decodes correctly.
- No existing test harness on `master` to add a unit test against (I see `add-test-environment` is a separate in-progress branch); happy to add a test if/when that lands, or if you'd like me to wire something up now.
